### PR TITLE
split out satellite bq schema fields to only apply to satellite pipelines

### DIFF
--- a/mirror/untar_files/sync_files.py
+++ b/mirror/untar_files/sync_files.py
@@ -123,8 +123,8 @@ class ScanfileMirror():
             output_blob.upload_from_filename(
                 filepath_rezipped, timeout=TIMEOUT_5_MINUTES)
             os.remove(filepath_rezipped)
-      os.remove(tmp_filepath)
-      shutil.rmtree(tmp_folder)
+    os.remove(tmp_filepath)
+    shutil.rmtree(tmp_folder)
 
   def _get_all_tarred_filenames(self) -> List[str]:
     """Get a list of all tarred filenames, minus the file extension.

--- a/mirror/untar_files/sync_files.py
+++ b/mirror/untar_files/sync_files.py
@@ -105,27 +105,26 @@ class ScanfileMirror():
         tmp_filepath, timeout=TIMEOUT_5_MINUTES)
 
     # Un-gzip and untar the folder
-    tfile = tarfile.open(tmp_filepath, 'r:gz')
-    for entry in tfile:
-      if entry.isfile():
-        unzipped_file = tfile.extractfile(entry)
-        if unzipped_file is None:
-          raise Exception(f'No data associated with member {entry}')
-        with unzipped_file:
-          # Re-zip the individual files for upload
-          filename_rezipped = pathlib.PurePosixPath(entry.name).name + '.gz'
-          filepath_rezipped = os.path.join(tmp_folder, filename_rezipped)
+    with tarfile.open(tmp_filepath, 'r:gz') as tfile:
+      for entry in tfile:
+        if entry.isfile():
+          unzipped_file = tfile.extractfile(entry)
+          if unzipped_file is None:
+            raise Exception(f'No data associated with member {entry}')
+          with unzipped_file:
+            # Re-zip the individual files for upload
+            filename_rezipped = pathlib.PurePosixPath(entry.name).name + '.gz'
+            filepath_rezipped = os.path.join(tmp_folder, filename_rezipped)
 
-          with gzip.open(filepath_rezipped, mode='wb') as rezipped_file:
-            shutil.copyfileobj(unzipped_file, rezipped_file)
-          output_blob = self.untarred_bucket.blob(
-              os.path.join(scan_type, tar_folder, filename_rezipped))
-          output_blob.upload_from_filename(
-              filepath_rezipped, timeout=TIMEOUT_5_MINUTES)
-          os.remove(filepath_rezipped)
-
-    os.remove(tmp_filepath)
-    shutil.rmtree(tmp_folder)
+            with gzip.open(filepath_rezipped, mode='wb') as rezipped_file:
+              shutil.copyfileobj(unzipped_file, rezipped_file)
+            output_blob = self.untarred_bucket.blob(
+                os.path.join(scan_type, tar_folder, filename_rezipped))
+            output_blob.upload_from_filename(
+                filepath_rezipped, timeout=TIMEOUT_5_MINUTES)
+            os.remove(filepath_rezipped)
+      os.remove(tmp_filepath)
+      shutil.rmtree(tmp_folder)
 
   def _get_all_tarred_filenames(self) -> List[str]:
     """Get a list of all tarred filenames, minus the file extension.

--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -155,18 +155,11 @@ class PipelineManualE2eTest(unittest.TestCase):
       written_rows = get_bq_rows(client, BQ_TEST_TABLE)
       self.assertEqual(len(written_rows), 53)
 
-      run_local_pipeline_satellite()
-
-      written_rows = get_bq_rows(client, BQ_TEST_TABLE)
-      self.assertEqual(len(written_rows), 57)
-
       # Domain appear different numbers of times in the test table depending on
       # how their measurement succeeded/failed.
       expected_single_domains = [
           'boingboing.net', 'box.com', 'google.com.ua', 'mos.ru', 'scribd.com',
-          'uploaded.to', 'www.blubster.com', 'www.orthodoxconvert.info',
-          'biblegateway.com', 'ar.m.wikipedia.org', 'www.ecequality.org',
-          'www.usacasino.com'
+          'uploaded.to', 'www.blubster.com', 'www.orthodoxconvert.info'
       ]
       expected_triple_domains = ['www.arabhra.org']
       expected_sextuple_domains = [
@@ -176,6 +169,30 @@ class PipelineManualE2eTest(unittest.TestCase):
       all_expected_domains = (
           expected_single_domains + expected_triple_domains * 3 +
           expected_sextuple_domains * 6)
+
+      written_domains = [row[0] for row in written_rows]
+      self.assertListEqual(
+          sorted(written_domains), sorted(all_expected_domains))
+
+    finally:
+      clean_up_bq_table(client, BQ_TEST_TABLE)
+
+  def test_satellite_pipeline_e2e(self) -> None:
+    """Test the satellite pipeline by running it locally."""
+    # Suppress some unittest socket warnings in beam code we don't control
+    warnings.simplefilter('ignore', ResourceWarning)
+    client = cloud_bigquery.Client()
+
+    try:
+      run_local_pipeline_satellite()
+
+      written_rows = get_bq_rows(client, BQ_TEST_TABLE)
+      self.assertEqual(len(written_rows), 4)
+
+      all_expected_domains = [
+          'biblegateway.com', 'ar.m.wikipedia.org', 'www.ecequality.org',
+          'www.usacasino.com'
+      ]
 
       written_domains = [row[0] for row in written_rows]
       self.assertListEqual(

--- a/pipeline/metadata/maxmind.py
+++ b/pipeline/metadata/maxmind.py
@@ -28,12 +28,12 @@ def _maxmind_reader(filepath: str) -> geoip2.database.Reader:
   # MaxMind Reader will only take a filepath,
   # so we need to write the file to local disk
   disk_filename = os.path.join('/tmp', os.path.basename(filepath))
-  disk_file = open(disk_filename, 'wb')
-  disk_file.write(f.read())
-  disk_file.close()
-  database = geoip2.database.Reader(disk_filename, mode=MODE_MEMORY)
-  os.remove(disk_filename)
-  return database
+  with open(disk_filename, 'wb') as disk_file:
+    disk_file.write(f.read())
+    disk_file.close()
+    database = geoip2.database.Reader(disk_filename, mode=MODE_MEMORY)
+    os.remove(disk_filename)
+    return database
 
 
 class MaxmindIpMetadata(IpMetadataInterface):

--- a/pipeline/metadata/maxmind.py
+++ b/pipeline/metadata/maxmind.py
@@ -30,10 +30,9 @@ def _maxmind_reader(filepath: str) -> geoip2.database.Reader:
   disk_filename = os.path.join('/tmp', os.path.basename(filepath))
   with open(disk_filename, 'wb') as disk_file:
     disk_file.write(f.read())
-    disk_file.close()
-    database = geoip2.database.Reader(disk_filename, mode=MODE_MEMORY)
-    os.remove(disk_filename)
-    return database
+  database = geoip2.database.Reader(disk_filename, mode=MODE_MEMORY)
+  os.remove(disk_filename)
+  return database
 
 
 class MaxmindIpMetadata(IpMetadataInterface):

--- a/pipeline/run_beam_tables.py
+++ b/pipeline/run_beam_tables.py
@@ -120,8 +120,8 @@ def get_firehook_beam_pipeline_runner(
   import firehook_resources  # pylint: disable=import-outside-toplevel
 
   return beam_tables.ScanDataBeamPipelineRunner(
-      firehook_resources.PROJECT_NAME, beam_tables.SCAN_BIGQUERY_SCHEMA,
-      firehook_resources.INPUT_BUCKET, firehook_resources.BEAM_STAGING_LOCATION,
+      firehook_resources.PROJECT_NAME, firehook_resources.INPUT_BUCKET,
+      firehook_resources.BEAM_STAGING_LOCATION,
       firehook_resources.BEAM_TEMP_LOCATION, caida_ip_metadata.CaidaIpMetadata,
       firehook_resources.CAIDA_FILE_LOCATION,
       firehook_resources.SIGNATURE_FILE_LOCATION, maxmind.MaxmindIpMetadata,

--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -37,6 +37,18 @@ class PipelineMainTest(unittest.TestCase):
 
   # pylint: disable=protected-access
 
+  def test_get_bigquery_schema(self) -> None:
+    """Test getting the right bigquery schema for data types."""
+    echo_schema = beam_tables._get_bigquery_schema('echo')
+    self.assertEqual(echo_schema, beam_tables.SCAN_BIGQUERY_SCHEMA)
+
+    dns_schema = beam_tables._get_bigquery_schema('dns')
+    all_satellite_top_level_columns = (
+        list(beam_tables.SCAN_BIGQUERY_SCHEMA.keys()) +
+        list(beam_tables.SATELLITE_BIGQUERY_SCHEMA.keys()))
+    self.assertListEqual(
+        list(dns_schema.keys()), all_satellite_top_level_columns)
+
   def test_get_beam_bigquery_schema(self) -> None:
     """Test making a bigquery schema for beam's table writing."""
     test_field = {
@@ -99,7 +111,7 @@ class PipelineMainTest(unittest.TestCase):
 
   def test_get_full_table_name(self) -> None:
     project = 'firehook-censoredplanet'
-    runner = beam_tables.ScanDataBeamPipelineRunner(project, {}, '', '', '',
+    runner = beam_tables.ScanDataBeamPipelineRunner(project, '', '', '',
                                                     FakeCaidaIpMetadata, '',
                                                     FAKE_SIGNATURE_FOLDER,
                                                     FakeMaxmindIpMetadata, '')
@@ -536,7 +548,6 @@ class PipelineMainTest(unittest.TestCase):
             'Set-Cookie: TS016c74f4=01671efb9a1a400535e215d6f76498a5887425fed793ca942baa75f16076e60e1350988222922fa06fc16f53ef016d9ecd38535fcabf14861525811a7c3459e91086df326f; Path=/',
             'X-Frame-Options: SAMEORIGIN',
         ],
-        'blockpage': None,
         'error': 'Incorrect web response: status lines don\'t match',
         'blocked': False,
         'success': False,
@@ -597,7 +608,7 @@ class PipelineMainTest(unittest.TestCase):
     p = TestPipeline()
     rows = (p | beam.Create(rows))
 
-    runner = beam_tables.ScanDataBeamPipelineRunner('', {}, '', '', '',
+    runner = beam_tables.ScanDataBeamPipelineRunner('', '', '', '',
                                                     FakeCaidaIpMetadata, '',
                                                     FAKE_SIGNATURE_FOLDER,
                                                     FakeMaxmindIpMetadata, '')
@@ -658,7 +669,7 @@ class PipelineMainTest(unittest.TestCase):
 
   def test_add_ip_metadata(self) -> None:
     """Test merging given IP metadata with given measurements."""
-    runner = beam_tables.ScanDataBeamPipelineRunner('', {}, '', '', '',
+    runner = beam_tables.ScanDataBeamPipelineRunner('', '', '', '',
                                                     FakeCaidaIpMetadata, '',
                                                     FAKE_SIGNATURE_FOLDER,
                                                     FakeMaxmindIpMetadata, '')
@@ -765,7 +776,15 @@ class PipelineMainTest(unittest.TestCase):
       '\u003cHTML\u003e\u003cHEAD\u003e\u003cTITLE\u003eA Website\u003c/TITLE\u003e\u003c/HEAD\u003e\u003cBODY\u003e\nThis site is not blocked!\u003cp\u003e\n\u003c/BODY\u003e\u003c/HTML\u003e\n',
       'HTTP/1.1 302 Moved Temporarily\r\nLocation: iterika.ru/blocked.html?UrlRedir=http%3A%2F%2Fblackberry.com%2f\r\nContent-Length: 0\r\nCache-Control: max-age=0, no-cache, no-store, must-revalidate\r\nPragma: no-cache\r\nConnection: close\r\n\r\n',
       'HTTP/1.1 302 Moved Temporarily\r\nLocation: https://www.divo.ru/%D0%B4%D0%B0%D0%BD%D0%BD%D1%8B%D0%B9-%D1%80%D0%B5%D1%81%D1%83%D1%80%D1%81-%D0%B7%D0%B0%D0%B1%D0%BB%D0%BE%D0%BA%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD/?UrlRedir=http%3A%2F%2Fwww.hizb-ut-tahrir.org%2f\r\nContent-Length: 0\r\nCache-Control: max-age=0, no-cache, no-store, must-revalidate\r\nPragma: no-cache\r\nConnection: close\r\n\r\n',
-      '''\u003chtml\u003e\r\n\u003chead\u003e\r\n\u003ctitle\u003eæ¡æç¶²é é»æ\u003c/title\u003e\r\n\u003cmeta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"\u003e\r\n\u003cMETA HTTP-EQUIV=\"PRAGMA\" CONTENT=\"NO-CACHE\"\u003e\r\n\u003cmeta name=\"viewport\" content=\"initial-scale=1.0\"\u003e\r\n\u003cstyle\u003e\r\n  #content {\r\n    border:3px solid#aaa;\r\n    background-color:#fff;\r\n    margin:1.5em;\r\n    padding:1.5em;\r\n    font-family:Tahoma,Helvetica,Arial,sans-serif;\r\n    font-size:1em;\r\n  }\r\n  h1 {\r\n    font-size:1.3em;\r\n    font-weight:bold;\r\n    color:#196390;\r\n  }\r\n  b {\r\n    font-weight:normal;\r\n    color:#196390;\r\n  }\r\n\u003c/style\u003e\r\n\u003c/head\u003e\r\n\u003cbody bgcolor=\"#e7e8e9\"\u003e\r\n\u003cdiv id=\"content\"\u003e\r\n\u003ch1\u003eéç¾è³è¨å®å¨é²è­· - æ¡æç¶²é é»æ\u003c/h1\u003e\r\n\u003cp\u003eå¦ææ¨çå°è©²ç«é¢è³è¨ï¼è¡¨ç¤ºæ¨è¢«å¤æ·å­åéæ­£å¸¸è¡çºç¶²ç« \u003cspan style=\"color:red;\"\u003e(æ¡æç¶²ç«)\u003c/span\u003e\u003c/p\u003e\r\n\u003cp\u003eè³è¨èª²å·²å°æ­¤ç¶²é é»æï¼å¦æç¢ºå®è©²ç¶²é æ¯è¢«èª¤å¤è«è¯ç¹«: éç¾è³è¨èª²-ç³»çµ±ç¶­éçµï¼è¬è¬ã\u003c/p\u003e\r\n\u003cp\u003e\u003cb\u003eä½¿ç¨è:\u003c/b\u003e 141.212.123.175 \u003c/p\u003e\r\n\u003cp\u003e\u003cb\u003eç¶²å:\u003c/b\u003e rtyutgyhefdafioasfjhjhi.com/ \u003c/p\u003e\r\n\u003cp\u003e\u003cb\u003eåé¡:\u003c/b\u003e command-and-control \u003c/p\u003e\r\n\u003c/div\u003e\r\n\u003c/body\u003e\r\n\u003c/html\u003e\r\n'''
+      '''\u003chtml\u003e\r\n\u003chead\u003e\r\n\u003ctitle\u003eæ¡æç¶²é é»æ\u003c/title\u003e\r\n\u003cmeta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"\u003e\r\n\u003cMETA HTTP-EQUIV=\"PRAGMA\" CONTENT=\"NO-CACHE\"\u003e\r\n\u003cmeta name=\"viewport\" content=\"initial-scale=1.0\"\u003e\r\n\u003cstyle\u003e\r\n  #content {\r\n    border:3px solid#aaa;\r\n    background-color:#fff;\r\n    margin:1.5em;\r\n    padding:1.5em;\r\n    font-family:Tahoma,Helvetica,Arial,sans-serif;\r\n    font-size:1em;\r\n  }\r\n  h1 {\r\n    font-size:1.3em;\r\n    font-weight:bold;\r\n    color:#196390;\r\n  }\r\n  b {\r\n    font-weight:normal;\r\n    color:#196390;\r\n  }\r\n\u003c/style\u003e\r\n\u003c/head\u003e\r\n\u003cbody bgcolor=\"#e7e8e9\"\u003e\r\n\u003cdiv id=\"content\"\u003e\r\n\u003ch1\u003eé
+
+ç¾è³è¨å®å
+
+¨é²è­· - æ¡æç¶²é é»æ\u003c/h1\u003e\r\n\u003cp\u003eå¦ææ¨çå°è©²ç«é¢è³è¨ï¼è¡¨ç¤ºæ¨è¢«å¤æ·å­åéæ­£å¸¸è¡çºç¶²ç« \u003cspan style=\"color:red;\"\u003e(æ¡æç¶²ç«)\u003c/span\u003e\u003c/p\u003e\r\n\u003cp\u003eè³è¨èª²å·²å°æ­¤ç¶²é é»æï¼å¦æç¢ºå®è©²ç¶²é æ¯è¢«èª¤å¤è«è¯ç¹«: é
+
+ç¾è³è¨èª²-ç³»çµ±ç¶­éçµï¼è¬è¬ã\u003c/p\u003e\r\n\u003cp\u003e\u003cb\u003eä½¿ç¨è
+
+:\u003c/b\u003e 141.212.123.175 \u003c/p\u003e\r\n\u003cp\u003e\u003cb\u003eç¶²å:\u003c/b\u003e rtyutgyhefdafioasfjhjhi.com/ \u003c/p\u003e\r\n\u003cp\u003e\u003cb\u003eåé¡:\u003c/b\u003e command-and-control \u003c/p\u003e\r\n\u003c/div\u003e\r\n\u003c/body\u003e\r\n\u003c/html\u003e\r\n'''
     ]
     # yapf: enable
 


### PR DESCRIPTION
I was trying to re-run the quack/hyperquack pipelines from head in this repo. But I realized that the new field for the satellite schema mean that we can't write successfully to the existing tables. It fails on schema mismatch errors.

Since we're not currently running the satellite pipeline I've broken out those field into a seperate part of the schema. Eventually we may want to recombine them so all the tables are uniform, but for now this should make it easier to keep developing the satellite pipeline without having to backfill the other pipelines any time we make schema changes. 

I've also removed the `blockpage` field in the schema for now. But I'll add it back in https://github.com/censoredplanet/censoredplanet-analysis/pull/12.

Testing: ran [catch up jobs](https://console.cloud.google.com/dataflow/jobs?project=firehook-censoredplanet) for the 4 existing pipelines.