### PR TITLE
changes to start satellite pipeline in prod

### DIFF
--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -67,7 +67,7 @@ def local_data_to_load_discard_and_echo(*_: List[Any]) -> List[str]:
   ]
 
 
-def local_data_to_load_3(*_: List[Any]) -> List[str]:
+def local_data_to_load_satellite(*_: List[Any]) -> List[str]:
   return [
       'pipeline/e2e_test_data/Satellitev1_2018-01-01/resolvers.json',
       'pipeline/e2e_test_data/Satellitev1_2018-01-01/tagged_resolvers.json',
@@ -112,14 +112,14 @@ def run_local_pipeline(incremental: bool = False) -> None:
 
 
 def run_local_pipeline_satellite() -> None:
-  # run_local_pipeline for satellite - scan_type must be 'dns'
+  # run_local_pipeline for satellite - scan_type must be 'satellite'
   # pylint: disable=protected-access
   test_runner = run_beam_tables.get_firehook_beam_pipeline_runner()
   test_runner._get_pipeline_options = get_local_pipeline_options  # type: ignore
-  test_runner._data_to_load = local_data_to_load_3  # type: ignore
+  test_runner._data_to_load = local_data_to_load_satellite  # type: ignore
 
-  test_runner.run_beam_pipeline('dns', True, JOB_NAME, BEAM_TEST_TABLE, None,
-                                None)
+  test_runner.run_beam_pipeline('satellite', True, JOB_NAME, BEAM_TEST_TABLE,
+                                None, None)
   # pylint: enable=protected-access
 
 

--- a/pipeline/run_beam_tables.py
+++ b/pipeline/run_beam_tables.py
@@ -137,8 +137,8 @@ def main(parsed_args: argparse.Namespace) -> None:
 
   if parsed_args.scan_type == 'all':
     selected_scan_types = list(beam_tables.ALL_SCAN_TYPES)
-    # TODO turn back on DNS once it works in the cloud.
-    selected_scan_types.remove('dns')
+    # TODO turn back on Satellite once it works in the cloud.
+    selected_scan_types.remove('satellite')
   else:
     selected_scan_types = [parsed_args.scan_type]
 

--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -40,12 +40,12 @@ class PipelineMainTest(unittest.TestCase):
     echo_schema = beam_tables._get_bigquery_schema('echo')
     self.assertEqual(echo_schema, beam_tables.SCAN_BIGQUERY_SCHEMA)
 
-    dns_schema = beam_tables._get_bigquery_schema('dns')
+    satellite_schema = beam_tables._get_bigquery_schema('satellite')
     all_satellite_top_level_columns = (
         list(beam_tables.SCAN_BIGQUERY_SCHEMA.keys()) +
         list(beam_tables.SATELLITE_BIGQUERY_SCHEMA.keys()))
     self.assertListEqual(
-        list(dns_schema.keys()), all_satellite_top_level_columns)
+        list(satellite_schema.keys()), all_satellite_top_level_columns)
 
   def test_get_beam_bigquery_schema(self) -> None:
     """Test making a bigquery schema for beam's table writing."""
@@ -801,10 +801,10 @@ class PipelineMainTest(unittest.TestCase):
     """Test flattening of Satellite measurements."""
 
     filenames = [
-        'gs://firehook-scans/dns/CP_Satellite-2020-09-02-12-00-01/interference.json',
-        'gs://firehook-scans/dns/CP_Satellite-2020-09-02-12-00-01/interference.json',
-        'gs://firehook-scans/dns/CP_Satellite-2020-09-02-12-00-01/interference.json',
-        'gs://firehook-scans/dns/CP_Satellite-2021-03-01-12-00-01/interference.json'
+        'gs://firehook-scans/satellite/CP_Satellite-2020-09-02-12-00-01/interference.json',
+        'gs://firehook-scans/satellite/CP_Satellite-2020-09-02-12-00-01/interference.json',
+        'gs://firehook-scans/satellite/CP_Satellite-2020-09-02-12-00-01/interference.json',
+        'gs://firehook-scans/satellite/CP_Satellite-2021-03-01-12-00-01/interference.json'
     ]
 
     # yapf: disable
@@ -1003,7 +1003,7 @@ class PipelineMainTest(unittest.TestCase):
     ]
     self.assertListEqual(result, expected)
 
-  def test_process_satellite(self) -> None:  # pylint: disable=no-self-use
+  def test_process_satellite_v1(self) -> None:  # pylint: disable=no-self-use
     """Test processing of Satellite v1 interference and tag files."""
     # yapf: disable
     _data = [
@@ -1061,7 +1061,7 @@ class PipelineMainTest(unittest.TestCase):
       lines = p | 'create data' >> beam.Create(data)
       lines2 = p | 'create tags' >> beam.Create(tags)
 
-      final = beam_tables._process_satellite(lines, lines2)
+      final = beam_tables._process_satellite_with_tags(lines, lines2)
       beam_test_util.assert_that(final, beam_test_util.equal_to(expected))
 
   def test_process_satellite_v2(self) -> None:  # pylint: disable=no-self-use
@@ -1120,7 +1120,7 @@ class PipelineMainTest(unittest.TestCase):
       lines = p | 'create data' >> beam.Create(data)
       lines2 = p | 'create tags' >> beam.Create(tags)
 
-      final = beam_tables._process_satellite(lines, lines2)
+      final = beam_tables._process_satellite_with_tags(lines, lines2)
       beam_test_util.assert_that(final, beam_test_util.equal_to(expected))
 
   def test_partition_satellite_input(self) -> None:  # pylint: disable=no-self-use


### PR DESCRIPTION
This doesn't fix the satellite pipeline, but it does update some smaller issues that were stopping beam jobs from starting successfully. This will make future fixes easier to understand.

To run a test pipeline run
`python3 -m pipeline.run_beam_tables --env=user --scan_type=satellite --full`