### PR TITLE
add svg solid background

### DIFF
--- a/system-diagram.svg
+++ b/system-diagram.svg
@@ -22,6 +22,7 @@
 </feMerge>
 </filter>
 </defs>
+<rect width="100%" height="100%" fill="white"/>
 <rect x="0" y="0" width="545" height="20" style="fill:rgb(81, 155, 247);filter:url(#drop-shadow);"/>
 <text x="24" y="13" style="font-family:Roboto;font-size:8.5px;fill:rgb(255, 255, 255);">Censored Planet Analysis</text>
 <rect x="0" y="740" width="545" height="10" style="fill:rgb(224, 224, 224);"/>


### PR DESCRIPTION
The system diagram looks silly in github darkmode because it has transparent background.
This adds a simple white background.