### PR TITLE
beam jobs fail when they create zero rows

### DIFF
--- a/pipeline/e2e_test_data/invalid_results.json
+++ b/pipeline/e2e_test_data/invalid_results.json
@@ -1,0 +1,2 @@
+invalid json only
+all lines are invalid

--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -77,6 +77,10 @@ def local_data_to_load_satellite(*_: List[Any]) -> List[str]:
   ]
 
 
+def local_data_to_load_invalid(*_: List[Any]) -> List[str]:
+  return ['pipeline/e2e_test_data/invalid_results.json']
+
+
 def get_local_pipeline_options(*_: List[Any]) -> PipelineOptions:
   # This method is used to monkey patch the get_pipeline_options method in
   # beam_tables in order to run a local pipeline.
@@ -119,6 +123,17 @@ def run_local_pipeline_satellite() -> None:
   test_runner._data_to_load = local_data_to_load_satellite  # type: ignore
 
   test_runner.run_beam_pipeline('satellite', True, JOB_NAME, BEAM_TEST_TABLE,
+                                None, None)
+  # pylint: enable=protected-access
+
+
+def run_local_pipeline_invalid() -> None:
+  # pylint: disable=protected-access
+  test_runner = run_beam_tables.get_firehook_beam_pipeline_runner()
+  test_runner._get_pipeline_options = get_local_pipeline_options  # type: ignore
+  test_runner._data_to_load = local_data_to_load_invalid  # type: ignore
+
+  test_runner.run_beam_pipeline('invalid', True, JOB_NAME, BEAM_TEST_TABLE,
                                 None, None)
   # pylint: enable=protected-access
 
@@ -200,6 +215,12 @@ class PipelineManualE2eTest(unittest.TestCase):
 
     finally:
       clean_up_bq_table(client, BQ_TEST_TABLE)
+
+  def test_invalid_pipeline(self) -> None:
+    with self.assertRaises(Exception) as context:
+      run_local_pipeline_invalid()
+    self.assertIn('Zero rows were created even though there were new files.',
+                  str(context.exception))
 
   def test_ipmetadata_init(self) -> None:
     caida_ip_metadata_db = caida_ip_metadata.get_firehook_caida_ip_metadata_db(

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ disable=abstract-method, # raises false positives in beam
         no-name-in-module, # raises false positives
         too-many-arguments, # better handled by reviewer judgement
         too-many-instance-attributes, # TODO remove
+        too-many-lines, # TODO remove
         too-many-locals, # better handled by reviewer judgement
         too-few-public-methods, # bad rule
         too-many-public-methods, # bad rule


### PR DESCRIPTION
Currently we're mostly bypassing individual bad/unparsable rows in json files. This is generally fine, but if the whole file is bad (or, in our current situation, the whole file is in a new format) then the beam job can succeed even though we've failed entirely.

I'm testing this in the e2e test because testing things like raised errors using beam's unit testing framework doesn't seem to work.

Ran a test job [here](https://console.cloud.google.com/dataflow/jobs/us-west1/2021-06-03_09_47_43-17483800278137902953;step=read%20file%20gs:?project=firehook-censoredplanet) and saw that it failed.