### PR TITLE
check blockpage fingerprints in file order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,17 +15,21 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
+
         python -m pip install --upgrade pip
         pip install mypy yapf pylint -r requirements.txt
     - name: Check types with mypy
       # Get all files with find because ** doesn't expand correctly.
+      # Run mypy twice, once to find missing stub packeges, then again after installing them.
       run: |
+        find . -iname '*.py' | xargs mypy --namespace-packages --explicit-package-bases || true
+        yes | mypy --install-types
         find . -iname '*.py' | xargs mypy --namespace-packages --explicit-package-bases
     - name: Check formatting with yapf
       run: |
         yapf --diff --recursive .
     - name: Check for lint errors with pylint
-    # Get all files with find because ** doesn't expand correctly.
+      # Get all files with find because ** doesn't expand correctly.
       run: |
         find . -iname '*.py' | xargs python -m pylint --rcfile=setup.cfg
     - name: Test with unittest

--- a/mirror/routeviews/bulk_download.py
+++ b/mirror/routeviews/bulk_download.py
@@ -18,7 +18,7 @@ import urllib.request
 
 import requests
 
-from google.cloud import storage
+from google.cloud import storage  # type: ignore
 
 import firehook_resources
 

--- a/mirror/routeviews/sync_routeviews.py
+++ b/mirror/routeviews/sync_routeviews.py
@@ -19,7 +19,7 @@ from pprint import pprint
 from typing import List
 import urllib.request
 
-from google.cloud import storage
+from google.cloud import storage  # type: ignore
 
 import firehook_resources
 

--- a/mirror/untar_files/sync_files.py
+++ b/mirror/untar_files/sync_files.py
@@ -37,7 +37,7 @@ from typing import List
 
 import requests
 from retry import retry
-from google.cloud import storage
+from google.cloud import storage  # type: ignore
 
 import firehook_resources
 

--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -26,7 +26,7 @@ from apache_beam.io.gcp.internal.clients import bigquery as beam_bigquery
 from apache_beam.io.gcp.gcsfilesystem import GCSFileSystem
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-from google.cloud import bigquery as cloud_bigquery
+from google.cloud import bigquery as cloud_bigquery  # type: ignore
 
 from pipeline.lookup_country_code import country_name_to_code
 from pipeline.metadata.flatten import Row

--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -28,8 +28,8 @@ import unittest
 import warnings
 
 from apache_beam.options.pipeline_options import PipelineOptions
-from google.cloud import bigquery as cloud_bigquery
-from google.cloud.exceptions import NotFound
+from google.cloud import bigquery as cloud_bigquery  # type: ignore
+from google.cloud.exceptions import NotFound  # type: ignore
 
 import firehook_resources
 from pipeline import run_beam_tables

--- a/pipeline/metadata/blockpage.py
+++ b/pipeline/metadata/blockpage.py
@@ -1,5 +1,6 @@
 """Matcher for response pages to blockpage signatures."""
 
+from collections import OrderedDict
 import json
 import io
 import pkgutil
@@ -25,7 +26,7 @@ def _load_signatures(filepath: str) -> Dict[str, re.Pattern]:
     raise FileNotFoundError(f"Couldn't find file {filepath}")
   content = io.TextIOWrapper(io.BytesIO(data), encoding='utf-8')
 
-  signatures = {}
+  signatures = OrderedDict()
   for line in content.readlines():
     if line != '\n':
       signature = json.loads(line.strip())

--- a/schedule_pipeline.py
+++ b/schedule_pipeline.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 import time
 
-from google.cloud import error_reporting
+from google.cloud import error_reporting  # type: ignore
 import schedule
 
 from mirror.untar_files.sync_files import get_firehook_scanfile_mirror

--- a/table/run_queries.py
+++ b/table/run_queries.py
@@ -21,7 +21,7 @@ python3 tables/run_queries.py
 import glob
 from pprint import pprint
 
-from google.cloud import bigquery as cloud_bigquery
+from google.cloud import bigquery as cloud_bigquery  # type: ignore
 
 import firehook_resources
 


### PR DESCRIPTION
This doesn't solve the whole problem with multiple blockpages matching, but it does make the blockpage matching deterministic (before it could depend on internal details of how python dictionaries are ordered)

Also added some mypy fixes to resolve git build issues that came from mypy upgrading to .9.0.0