### PR TITLE
classify content mismatch for hyperquack v2 and match some new errors

### DIFF
--- a/docs/merged_reduced_scans_table.md
+++ b/docs/merged_reduced_scans_table.md
@@ -117,7 +117,10 @@ Mismatch Errors are used when the connection is successful, but the content rece
 |                         |
 | **Mismatch Errors**     | The connection completed successfully, but the content returned didn't match the content expected for the domain. |
 |                         |
+| HyperQuack v1 only      |
 | response_mismatch       | Received a different response from the one expected. </br> For Discard no response is expected and any response is a mismatch, </br> for Echo a mirrored response is expected and anything else is a mismatch. |
 | status_mismatch         | The HTTP status code didn't match, eg. `403` instead of `200` |
 | body_mismatch           | The HTTP body didn't match, potentially a blockpage |
 | tls_mismatch            | An element of the TLS connection (certificate, cipher suite, or TLS version) didn't match |
+| HyperQuack v1 and v2    |
+| template_mismatch       | Some element of the response did not match the expected template |

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ split_before_expression_after_opening_paren = True
 disable=abstract-method, # raises false positives in beam
         arguments-differ, # raises false positives in beam
         bad-indentation, # covered by yapf
+        consider-using-with, # better handled by reviewer judgement
         duplicate-code, # better handled by reviewer judgement
         fixme, # bad rule
         import-error, # raises false positives

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -24,13 +24,17 @@ CREATE TEMP FUNCTION CleanError(error STRING) AS (
 # Classify all errors into a small set of enums
 #
 # Input is a nullable error string from the raw data
-# Source is one of "ECHO", "Discard, "HTTP", "HTTPS"
+# Source is one of "ECHO", "DISCARD, "HTTP", "HTTPS"
 #
 # Output is a string of the format "stage/outcome"
 # Documentation of this enum is at
 # https://github.com/censoredplanet/censoredplanet-analysis/blob/master/docs/tables.md#outcome-classification
-CREATE TEMP FUNCTION ClassifyError(error STRING, source STRING) AS (
+CREATE TEMP FUNCTION ClassifyError(error STRING, source STRING, template_match BOOL) AS (
   CASE
+    # Content mismatch for hyperquack v2 which doesn't write
+    # content verification failures in the error field.
+    WHEN (NOT template_match AND (error is NULL OR error = "")) then "content/template_mismatch"
+
     # Success
     WHEN (error is NULL OR error = "") then "complete/success"
 
@@ -57,6 +61,7 @@ CREATE TEMP FUNCTION ClassifyError(error STRING, source STRING) AS (
     WHEN ENDS_WITH(error, "readLoopPeekFailLocked: <nil>") THEN "tls/tls.failed"
     WHEN ENDS_WITH(error, "missing ServerKeyExchange message") THEN "tls/tls.failed"
     WHEN ENDS_WITH(error, "no mutual cipher suite") THEN "tls/tls.failed"
+    WHEN REGEXP_CONTAINS(error, "TLS handshake timeout") THEN "tls/timeout"
 
     # Write failures
     WHEN ENDS_WITH(error, "write: connection reset by peer") THEN "write/tcp.reset"
@@ -68,12 +73,12 @@ CREATE TEMP FUNCTION ClassifyError(error STRING, source STRING) AS (
     WHEN ENDS_WITH(error, "shutdown: transport endpoint is not connected") THEN "read/system"
     # TODO: for HTTPS this error could potentially also be SNI blocking in the tls stage
     # find a way to diffentiate this case.
-    WHEN ENDS_WITH(error, "read: connection reset by peer") THEN "read/tcp.reset"
+    WHEN REGEXP_CONTAINS(error, "read: connection reset by peer") THEN "read/tcp.reset"
 
     # HTTP content verification failures
     WHEN (source != "ECHO" AND REGEXP_CONTAINS(error, "unexpected EOF")) THEN "read/http.truncated_response"
     WHEN (source != "ECHO" AND REGEXP_CONTAINS(error, "EOF")) THEN "read/http.empty"
-    WHEN ENDS_WITH(error, "http: server closed idle connection") THEN "read/http.truncated_response"
+    WHEN REGEXP_CONTAINS(error, "http: server closed idle connection") THEN "read/http.truncated_response"
     WHEN ENDS_WITH(error, "trailer header without chunked transfer encoding") THEN "http/http.invalid"
     WHEN ENDS_WITH(error, "response missing Location header") THEN "http/http.invalid"
     WHEN REGEXP_CONTAINS(error, "bad Content-Length") THEN "http/http.invalid"
@@ -127,7 +132,7 @@ WITH
     country,
     netblock,
     CleanError(error) AS result,
-    ClassifyError(error, "DISCARD") as outcome,
+    ClassifyError(error, "DISCARD", success) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.discard_scan`
   GROUP BY date, source, country, domain, netblock, result, outcome
@@ -140,7 +145,7 @@ WITH
     country,
     netblock,
     CleanError(error) AS result,
-    ClassifyError(error, "ECHO") as outcome,
+    ClassifyError(error, "ECHO", success) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.echo_scan`
   GROUP BY date, source, country, domain, netblock, result, outcome
@@ -153,7 +158,7 @@ WITH
     country,
     netblock,
     CleanError(error) AS result,
-    ClassifyError(error, "HTTP") as outcome,
+    ClassifyError(error, "HTTP", success) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.http_scan`
   GROUP BY date, source, country, domain, netblock, result, outcome
@@ -166,7 +171,7 @@ WITH
     country,
     netblock,
     CleanError(error) AS result,
-    ClassifyError(error, "HTTPS") as outcome,
+    ClassifyError(error, "HTTPS", success) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.https_scan`
   GROUP BY date, source, country, domain, netblock, result, outcome


### PR DESCRIPTION
This is the simple/hacky way to fix the different content in the error field for hyperquack v2. The correct way will be to move this logic into the beam pipeline itself.

Two major changes:
- Hyperquack v2 doesn't include the "Incorrect web response *" errors that v1 does. But it does include a `template_mismatch` field. This uses that field to separate out content problems.
- There are a few new errors that shows up in v2 vs v1. This includes those in the enum.

One minor change:
- Suppressing a new warning that appeared in the latest version of pylint.

New errors are
- Get "https://[IP]:[PORT]/": http: server closed idle connection (Client.Timeout exceeded while awaiting headers)
- Get "https://[IP]:[PORT]/": net/http: TLS handshake timeout
- Get "https://[IP]:[PORT]/": net/http: TLS handshake timeout (Client.Timeout exceeded while awaiting headers)
- Get "https://[IP]:[PORT]/": read tcp [IP]:[PORT]->[IP]:[PORT]: read: connection reset by peer (Client.Timeout exceeded while awaiting headers)

which map to
- `read/http.truncated_response`
- `tls/timeout`
- `tls/timeout`
- `read/tcp.reset`

respectively

Tested: ran queries over the prod data
- saw data transition form a bunch of different `content/*` outcomes to just `content/template_mismatch`
- there are no `unknown` errors in the final dataset

![4GHrtr7tDXAYNq5](https://user-images.githubusercontent.com/1127209/123867906-f93fd380-d8fc-11eb-9311-b3f1a8a6d7b5.png)

Unexpectedly there were some `content/template_mismatch` errors surfaced in the v1 data as well. This can only happen when `Success` (the v1 (and boolean opposite) field name for `matches_template` in v2 is false but `error` is null/empty). Looking at the data I think there is probably a v1 error where sometimes the "Incorrect web response *" data in `error` wasn't being populated, so this is actually a reasonable thing to do. It's also only a small percentage of the data.