### PR TITLE
normalize all control domains

### DIFF
--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -127,7 +127,7 @@ WITH
   AllScans AS (
   SELECT
     date,
-    domain,
+    IF(is_control, "CONTROL", domain) as domain,
     "DISCARD" AS source,
     country,
     netblock,
@@ -140,7 +140,7 @@ WITH
   UNION ALL
   SELECT
     date,
-    domain,
+    IF(is_control, "CONTROL", domain) as domain,
     "ECHO" AS source,
     country,
     netblock,
@@ -153,7 +153,7 @@ WITH
   UNION ALL
   SELECT
     date,
-    domain,
+    IF(is_control, "CONTROL", domain) as domain,
     "HTTP" AS source,
     country,
     netblock,
@@ -166,7 +166,7 @@ WITH
   UNION ALL
   SELECT
     date,
-    domain,
+    IF(is_control, "CONTROL", domain) as domain,
     "HTTPS" AS source,
     country,
     netblock,


### PR DESCRIPTION
[hyperquack v2 measurements](https://github.com/censoredplanet/censoredplanet-analysis/pull/23) generate a bunch of control domains like control-123456789.com which don't add unique info and clutter up the dashboard. This normalizes all control domains to the same name.

tested: ran on prod tables