### PR TITLE
add failed controls info to table

### DIFF
--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -131,11 +131,12 @@ WITH
     "DISCARD" AS source,
     country,
     netblock,
+    controls_failed,
     CleanError(error) AS result,
     ClassifyError(error, "DISCARD", success) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.discard_scan`
-  GROUP BY date, source, country, domain, netblock, result, outcome
+  GROUP BY date, source, country, domain, netblock, controls_failed, result, outcome
 
   UNION ALL
   SELECT
@@ -144,11 +145,12 @@ WITH
     "ECHO" AS source,
     country,
     netblock,
+    controls_failed,
     CleanError(error) AS result,
     ClassifyError(error, "ECHO", success) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.echo_scan`
-  GROUP BY date, source, country, domain, netblock, result, outcome
+  GROUP BY date, source, country, domain, netblock, controls_failed, result, outcome
 
   UNION ALL
   SELECT
@@ -157,11 +159,12 @@ WITH
     "HTTP" AS source,
     country,
     netblock,
+    controls_failed,
     CleanError(error) AS result,
     ClassifyError(error, "HTTP", success) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.http_scan`
-  GROUP BY date, source, country, domain, netblock, result, outcome
+  GROUP BY date, source, country, domain, netblock, controls_failed, result, outcome
 
   UNION ALL
   SELECT
@@ -170,11 +173,12 @@ WITH
     "HTTPS" AS source,
     country,
     netblock,
+    controls_failed,
     CleanError(error) AS result,
     ClassifyError(error, "HTTPS", success) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.https_scan`
-  GROUP BY date, source, country, domain, netblock, result, outcome
+  GROUP BY date, source, country, domain, netblock, controls_failed, result, outcome
 )
 SELECT *
 FROM AllScans
@@ -199,6 +203,7 @@ AS (
     netblock,
     asn,
     as_full_name AS as_name,
+    controls_failed,
     result,
     outcome,
     count


### PR DESCRIPTION
Would it be clearer for dashboard purposes to reverse this field and instead have a `controls_succeeded` field?