### PR TITLE
add a specific outcome for blockpages

### DIFF
--- a/docs/merged_reduced_scans_table.md
+++ b/docs/merged_reduced_scans_table.md
@@ -124,3 +124,4 @@ Mismatch Errors are used when the connection is successful, but the content rece
 | tls_mismatch            | An element of the TLS connection (certificate, cipher suite, or TLS version) didn't match |
 | HyperQuack v1 and v2    |
 | template_mismatch       | Some element of the response did not match the expected template |
+| blockpage               | The response was unexpected and matched a [known blockpage]((https://github.com/censoredplanet/censoredplanet-analysis/blob/master/pipeline/metadata/data/blockpage_signatures.json)) |


### PR DESCRIPTION
This adds blockpage matches as a possible outcome. Blockpages are a subset of content mismatches but provide much clearer evidence of blocking, so they're worth calling out individually.

This doesn't do anything to show which specific blockpage matched since that would require displaying a new field in the dashboard, whereas this change just shows up automatically. We can think more about if/how to do that in the future.

Here's an [dashboard example](https://datastudio.google.com/s/saNPMZcHVco) of how this looks investigating blogger blocking in Iran on HTTP.
![568GVX7jE9M3KMP](https://user-images.githubusercontent.com/1127209/126824358-991f4a9a-eb0b-4bc3-aa6c-1009be6455eb.png)
