### PR TITLE
add random string to temp filename

### DIFF
--- a/pipeline/metadata/maxmind.py
+++ b/pipeline/metadata/maxmind.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import tempfile
 from typing import Optional, Tuple
 
 import geoip2.database
@@ -27,12 +28,11 @@ def _maxmind_reader(filepath: str) -> geoip2.database.Reader:
 
   # MaxMind Reader will only take a filepath,
   # so we need to write the file to local disk
-  disk_filename = os.path.join('/tmp', os.path.basename(filepath))
-  with open(disk_filename, 'wb') as disk_file:
+  with tempfile.NamedTemporaryFile() as disk_file:
     disk_file.write(f.read())
-  database = geoip2.database.Reader(disk_filename, mode=MODE_MEMORY)
-  os.remove(disk_filename)
-  return database
+    disk_filename = disk_file.name
+    database = geoip2.database.Reader(disk_filename, mode=MODE_MEMORY)
+    return database
 
 
 class MaxmindIpMetadata(IpMetadataInterface):


### PR DESCRIPTION
This will help avoid the [error I started seeing](https://github.com/censoredplanet/jigsaw-cp-tracker/issues/12#issuecomment-887796514) when I ran some recent side jobs.

Echo job with errors: [here](https://console.cloud.google.com/dataflow/jobs/us-west1/2021-07-26_11_45_15-14313488031636688310?project=firehook-censoredplanet)
Echo job with this fix and no errors: [here](https://console.cloud.google.com/dataflow/jobs/us-west1/2021-07-27_13_14_52-6327735488330406382;bottomTab=JOB_LOGS;expandBottomPanel=true;logsSeverity=WARNING?project=firehook-censoredplanet)

I'm not 100% sure what change started causing this error. At this point I suspect it's a change in the worker isolation in beam. Hopefully by pushing this we can fix it before it ever comes up in prod.