### PR TITLE
fix query by grouping by category

### DIFF
--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -136,7 +136,7 @@ AS (
 
 CREATE OR REPLACE TABLE `firehook-censoredplanet.derived.merged_reduced_scans_no_as`
 PARTITION BY date
-CLUSTER BY source, country, category, domain, netblock
+CLUSTER BY source, country, domain, netblock
 AS (
 WITH
   AllScans AS (
@@ -152,7 +152,7 @@ WITH
     ClassifyError(error, "DISCARD", success, blockpage, page_signature) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.discard_scan`
-  GROUP BY date, source, country, domain, netblock, controls_failed, result, outcome
+  GROUP BY date, source, country, category, domain, netblock, controls_failed, result, outcome
 
   UNION ALL
   SELECT
@@ -167,7 +167,7 @@ WITH
     ClassifyError(error, "ECHO", success, blockpage, page_signature) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.echo_scan`
-  GROUP BY date, source, country, domain, netblock, controls_failed, result, outcome
+  GROUP BY date, source, country, category, domain, netblock, controls_failed, result, outcome
 
   UNION ALL
   SELECT
@@ -182,7 +182,7 @@ WITH
     ClassifyError(error, "HTTP", success, blockpage, page_signature) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.http_scan`
-  GROUP BY date, source, country, domain, netblock, controls_failed, result, outcome
+  GROUP BY date, source, country, category, domain, netblock, controls_failed, result, outcome
 
   UNION ALL
   SELECT
@@ -197,7 +197,7 @@ WITH
     ClassifyError(error, "HTTPS", success, blockpage, page_signature) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.https_scan`
-  GROUP BY date, source, country, domain, netblock, controls_failed, result, outcome
+  GROUP BY date, source, country, category, domain, netblock, controls_failed, result, outcome
 )
 SELECT *
 FROM AllScans

--- a/table/queries/merged_scans.sql
+++ b/table/queries/merged_scans.sql
@@ -23,7 +23,7 @@ CREATE TEMP FUNCTION CleanError(error string) AS (
 
 CREATE OR REPLACE TABLE `firehook-censoredplanet.derived.merged_error_scans`
 PARTITION BY date
-CLUSTER BY source, country, category, domain, result
+CLUSTER BY source, country, domain, result
 as (
 WITH
   AllScans AS (


### PR DESCRIPTION
The query I modified in https://github.com/censoredplanet/censoredplanet-analysis/commit/fe4dc13a7675070ea6883b6d54bf323366eca7d4 is having an error due to grouping incorrectly. This fixes that grouping.

Removed the category clustering since it turns out you can only cluster by 4 things max.