### PR TITLE
stricter data validation for tagged_answers.json

### DIFF
--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -335,9 +335,17 @@ def _read_satellite_tags(filename: str, line: str) -> Iterator[Row]:
         'ip': scan['resolver'],
         'country': country_name_to_code(scan['country'])
     }
-  else:
+  elif 'http' in scan:
     # from tagged_answers.json
-    tags = scan
+    tags = {
+        'ip': scan['ip'],
+        'http': scan['http'],
+        'cert': scan['cert'],
+        'asname': scan['asname'],
+        'asnum': scan['asnum'],
+    }
+  else:
+    raise Exception(f"Unknown satellite tag format: {scan}")
   tags['date'] = re.findall(r'\d\d\d\d-\d\d-\d\d', filename)[0]
   yield tags
 


### PR DESCRIPTION
Before this change my attempt at running a full satellite backfill job (minus received ip tagging) was failing with the bq write error

```
"message": "Error while reading data, error message: JSON parsing error in row starting at position 576519: No such field: trust."
```

From @avirkud this field was coming from an old entry in the tagged_answers.json file.

> The 'trust' field was removed Jan. 22, 2019 - it corresponded to the field p443.https.tls.validation.browser_trusted in the Censys data.

This change makes us a little stricter about which field we read in from that file.

After this change I was able to run [a job](https://console.cloud.google.com/dataflow/jobs/us-west2/2021-08-06_08_13_35-1928139109516309757;mainTab=JOB_METRICS;bottomTab=JOB_LOGS;expandBottomPanel=true;logsSeverity=ERROR?project=firehook-censoredplanet) which didn't see that error. (Didn't succeed either, but still progress.)
