### PR TITLE
add dbip data

### DIFF
--- a/firehook_resources.py
+++ b/firehook_resources.py
@@ -27,6 +27,7 @@ METADATA_BUCKET = 'censoredplanet_geolocation'
 ROUTEVIEW_PATH = 'caida/routeviews/'
 CAIDA_FILE_LOCATION = f'gs://{METADATA_BUCKET}/caida/'
 MAXMIND_FILE_LOCATION = f'gs://{METADATA_BUCKET}/maxmind/'
+DBIP_FILE_LOCATION = f'gs://{METADATA_BUCKET}/dbip/'
 
 # Temp Buckets
 BEAM_STAGING_LOCATION = 'gs://firehook-dataflow-test/staging'

--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -33,7 +33,7 @@ from google.cloud.exceptions import NotFound  # type: ignore
 
 import firehook_resources
 from pipeline import run_beam_tables
-from pipeline.metadata import caida_ip_metadata, maxmind
+from pipeline.metadata import caida_ip_metadata, maxmind, dbip
 
 # The test table is written into the <project>:<username> dataset
 username = pwd.getpwuid(os.getuid()).pw_name
@@ -307,6 +307,18 @@ class PipelineManualE2eTest(unittest.TestCase):
 
     self.assertEqual(metadata,
                      ('1.1.1.0/24', 13335, 'CLOUDFLARENET', None, None, 'AU'))
+
+  def test_dbip_init(self) -> None:
+    """Test DBIP database access."""
+    dbip_data = dbip.DbipMetadata(firehook_resources.DBIP_FILE_LOCATION)
+
+    (org, asn) = dbip_data.get_org('1.211.95.160')
+    self.assertEqual(org, "Boranet")
+    self.assertEqual(asn, 3786)
+
+    (org, asn) = dbip_data.get_org('1.0.0.0')
+    self.assertEqual(org, None)
+    self.assertEqual(asn, 13335)
 
 
 # This test is not run by default in unittest because it takes about a minute

--- a/pipeline/metadata/dbip.py
+++ b/pipeline/metadata/dbip.py
@@ -1,0 +1,54 @@
+"""IP classificaation using the dbip database"""
+
+import logging
+import os
+from typing import Optional, Tuple
+
+import geoip2.database
+
+from pipeline.metadata.mmdb_reader import mmdb_reader
+
+DBIP_ISP = 'dbip-isp-2021-07-01.mmdb'
+
+
+class DbipMetadata():
+  """Lookup database for DBIP ASN and organization metadata."""
+
+  def __init__(self, dbip_folder: str) -> None:
+    """Create a DBIP Database.
+
+      Args:
+        dbip_folder: a folder containing a dbip file.
+          Either a gcs filepath or a local system folder.
+    """
+    dbip_path = os.path.join(dbip_folder, DBIP_ISP)
+    self.dbip_isp = mmdb_reader(dbip_path)
+
+  def get_org(self, ip: str) -> Tuple[Optional[str], Optional[int]]:
+    """Lookup the organization for an ip
+
+    Args:
+      ip: ip like 1.1.1.1
+
+    Returns:
+      Tuple of organization name and asn
+    """
+    try:
+      ip_info = self.dbip_isp.enterprise(ip)
+      return (ip_info.traits.organization,
+              ip_info.traits.autonomous_system_number)
+
+    except (ValueError, geoip2.errors.AddressNotFoundError) as e:
+      logging.warning('DBIP: %s\n', e)
+    return (None, None)
+
+
+class FakeDbipMetadata():
+  """A fake lookup table for testing DbipMetadata."""
+
+  def __init__(self, _: str) -> None:
+    super()
+
+  # pylint: disable=no-self-use
+  def get_org(self, _: str) -> Tuple[Optional[str], Optional[int]]:
+    return ("Fake Cloudflare Sub-Org", 13335)

--- a/pipeline/metadata/mmdb_reader.py
+++ b/pipeline/metadata/mmdb_reader.py
@@ -1,0 +1,27 @@
+"""Method to read in mmdb files"""
+
+import tempfile
+
+import geoip2.database
+from geoip2.database import MODE_MEMORY
+import apache_beam.io.filesystems as apache_filesystems
+
+
+def mmdb_reader(filepath: str) -> geoip2.database.Reader:
+  """Return a reader for an MMDB database.
+
+    Args:
+      filepath: gcs or local fileststem path to .mmdb file
+
+    Returns:
+      geoip2.database.Reader
+  """
+  f = apache_filesystems.FileSystems.open(filepath)
+
+  # geoip2 reader will only take a filepath,
+  # so we need to write the file to local disk
+  with tempfile.NamedTemporaryFile() as disk_file:
+    disk_file.write(f.read())
+    disk_filename = disk_file.name
+    database = geoip2.database.Reader(disk_filename, mode=MODE_MEMORY)
+    return database

--- a/pipeline/run_beam_tables.py
+++ b/pipeline/run_beam_tables.py
@@ -27,6 +27,7 @@ from typing import Optional, List, Tuple
 
 from pipeline import beam_tables
 from pipeline.metadata import caida_ip_metadata
+from pipeline.metadata import dbip
 from pipeline.metadata import maxmind
 
 
@@ -138,7 +139,8 @@ def get_firehook_beam_pipeline_runner(
       firehook_resources.BEAM_STAGING_LOCATION,
       firehook_resources.BEAM_TEMP_LOCATION, caida_ip_metadata.CaidaIpMetadata,
       firehook_resources.CAIDA_FILE_LOCATION, maxmind.MaxmindIpMetadata,
-      firehook_resources.MAXMIND_FILE_LOCATION)
+      firehook_resources.MAXMIND_FILE_LOCATION, dbip.DbipMetadata,
+      firehook_resources.DBIP_FILE_LOCATION)
 
 
 def main(parsed_args: argparse.Namespace) -> None:

--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -26,6 +26,7 @@ import apache_beam.testing.util as beam_test_util
 from pipeline import beam_tables
 from pipeline.metadata.fake_caida_ip_metadata import FakeCaidaIpMetadata
 from pipeline.metadata.maxmind import FakeMaxmindIpMetadata
+from pipeline.metadata.dbip import FakeDbipMetadata
 from pipeline.metadata import flatten
 
 
@@ -110,7 +111,8 @@ class PipelineMainTest(unittest.TestCase):
     project = 'firehook-censoredplanet'
     runner = beam_tables.ScanDataBeamPipelineRunner(project, '', '', '',
                                                     FakeCaidaIpMetadata, '',
-                                                    FakeMaxmindIpMetadata, '')
+                                                    FakeMaxmindIpMetadata, '',
+                                                    FakeDbipMetadata, '')
 
     full_name = runner._get_full_table_name('prod.echo_scan')
     self.assertEqual(full_name, 'firehook-censoredplanet:prod.echo_scan')
@@ -184,7 +186,8 @@ class PipelineMainTest(unittest.TestCase):
 
     runner = beam_tables.ScanDataBeamPipelineRunner('', '', '', '',
                                                     FakeCaidaIpMetadata, '',
-                                                    FakeMaxmindIpMetadata, '')
+                                                    FakeMaxmindIpMetadata, '',
+                                                    FakeDbipMetadata, '')
 
     rows_with_metadata = runner._add_metadata(rows)
     beam_test_util.assert_that(
@@ -244,7 +247,8 @@ class PipelineMainTest(unittest.TestCase):
     """Test merging given IP metadata with given measurements."""
     runner = beam_tables.ScanDataBeamPipelineRunner('', '', '', '',
                                                     FakeCaidaIpMetadata, '',
-                                                    FakeMaxmindIpMetadata, '')
+                                                    FakeMaxmindIpMetadata, '',
+                                                    FakeDbipMetadata, '')
 
     metadatas = list(
         runner._add_ip_metadata('2020-01-01', ['1.1.1.1', '8.8.8.8']))
@@ -257,6 +261,7 @@ class PipelineMainTest(unittest.TestCase):
         'as_full_name': 'Cloudflare Inc.',
         'as_class': 'Content',
         'country': 'US',
+        'organization': 'Fake Cloudflare Sub-Org',
     }
 
     expected_key_2: beam_tables.DateIpKey = ('2020-01-01', '8.8.8.8')
@@ -267,6 +272,7 @@ class PipelineMainTest(unittest.TestCase):
         'as_full_name': 'Google LLC',
         'as_class': 'Content',
         'country': 'US',
+        # No organization data is added since the ASN doesn't match dbip
     }
 
     self.assertListEqual(metadatas, [(expected_key_1, expected_value_1),
@@ -278,7 +284,8 @@ class PipelineMainTest(unittest.TestCase):
 
     runner = beam_tables.ScanDataBeamPipelineRunner('', '', '', '',
                                                     FakeCaidaIpMetadata, '',
-                                                    FakeMaxmindIpMetadata, '')
+                                                    FakeMaxmindIpMetadata, '',
+                                                    FakeDbipMetadata, '')
 
     metadatas = list(runner._add_ip_metadata('2020-01-01', ['1.1.1.3']))
 
@@ -292,6 +299,7 @@ class PipelineMainTest(unittest.TestCase):
         'as_full_name': 'Cloudflare Inc.',
         'as_class': 'Content',
         'country': None,
+        'organization': 'Fake Cloudflare Sub-Org',
     }
     expected_value_1['country'] = 'AU'
 

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -125,7 +125,8 @@ AS (
     date,
     netblock,
     asn,
-    as_full_name AS as_full_name
+    as_full_name AS as_full_name,
+    organization AS organization
   FROM (
     SELECT * FROM `firehook-censoredplanet.base.discard_scan` UNION ALL
     SELECT * FROM `firehook-censoredplanet.base.echo_scan` UNION ALL
@@ -140,6 +141,7 @@ CLUSTER BY source, country, domain, netblock
 AS (
 WITH
   AllScans AS (
+
   SELECT
     date,
     IF(is_control, "CONTROL", domain) as domain,
@@ -147,12 +149,13 @@ WITH
     "DISCARD" AS source,
     country,
     netblock,
+    organization,
     controls_failed,
     CleanError(error) AS result,
     ClassifyError(error, "DISCARD", success, blockpage, page_signature) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.discard_scan`
-  GROUP BY date, source, country, category, domain, netblock, controls_failed, result, outcome
+  GROUP BY date, source, country, category, domain, netblock, organization, controls_failed, result, outcome
 
   UNION ALL
   SELECT
@@ -162,14 +165,16 @@ WITH
     "ECHO" AS source,
     country,
     netblock,
+    organization,
     controls_failed,
     CleanError(error) AS result,
     ClassifyError(error, "ECHO", success, blockpage, page_signature) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.echo_scan`
-  GROUP BY date, source, country, category, domain, netblock, controls_failed, result, outcome
+  GROUP BY date, source, country, category, domain, netblock, organization, controls_failed, result, outcome
 
   UNION ALL
+
   SELECT
     date,
     IF(is_control, "CONTROL", domain) as domain,
@@ -177,12 +182,13 @@ WITH
     "HTTP" AS source,
     country,
     netblock,
+    organization,
     controls_failed,
     CleanError(error) AS result,
     ClassifyError(error, "HTTP", success, blockpage, page_signature) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.http_scan`
-  GROUP BY date, source, country, category, domain, netblock, controls_failed, result, outcome
+  GROUP BY date, source, country, category, domain, netblock, organization, controls_failed, result, outcome
 
   UNION ALL
   SELECT
@@ -192,12 +198,13 @@ WITH
     "HTTPS" AS source,
     country,
     netblock,
+    organization,
     controls_failed,
     CleanError(error) AS result,
     ClassifyError(error, "HTTPS", success, blockpage, page_signature) as outcome,
     count(1) AS count
   FROM `firehook-censoredplanet.base.https_scan`
-  GROUP BY date, source, country, category, domain, netblock, controls_failed, result, outcome
+  GROUP BY date, source, country, category, domain, netblock, organization, controls_failed, result, outcome
 )
 SELECT *
 FROM AllScans
@@ -223,11 +230,12 @@ AS (
     netblock,
     asn,
     as_full_name AS as_name,
+    organization,
     controls_failed,
     result,
     outcome,
     count
   FROM `firehook-censoredplanet.derived.merged_reduced_scans_no_as`
   LEFT JOIN `firehook-censoredplanet.derived.merged_net_as`
-  USING (date, netblock)
+  USING (date, netblock, organization)
 );

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -119,7 +119,7 @@ CREATE TEMP FUNCTION ClassifyError(error STRING,
 
 CREATE OR REPLACE TABLE `firehook-censoredplanet.derived.merged_net_as`
 PARTITION BY date
-CLUSTER BY netblock
+CLUSTER BY organization
 AS (
   SELECT DISTINCT
     date,
@@ -137,7 +137,7 @@ AS (
 
 CREATE OR REPLACE TABLE `firehook-censoredplanet.derived.merged_reduced_scans_no_as`
 PARTITION BY date
-CLUSTER BY source, country, domain, netblock
+CLUSTER BY source, country, organization, domain
 AS (
 WITH
   AllScans AS (


### PR DESCRIPTION
This uses a single dated dbip database to add organization info to the output tables.

Because it's only a single database and not accounting for past ip churn we are only adding organizations where the asn from dbip matches the asn from caida. This means older data will have more missing organizations, but is a reasonable short-term solution.

This also needs some future refactoring to move all the asn/geolocation business logic building up in `_add_ip_metadata` into its own more contained module. I'd rather send this now so we can get the format of the production tables (adding the org column) finalized as early as possible.