### PR TITLE
add fixes for new lint errors

### DIFF
--- a/mirror/internal/sync.py
+++ b/mirror/internal/sync.py
@@ -45,7 +45,7 @@ class RepositoryMirror():
     """Load history for local versions of files."""
     if not os.path.exists(FILE_HISTORY):
       return {}
-    with open(FILE_HISTORY) as f:
+    with open(FILE_HISTORY, encoding='utf-8') as f:
       history = f.read()
     return json.loads(history)
 
@@ -100,7 +100,7 @@ class RepositoryMirror():
       # Update history with new etag
       etag = req.headers.get('ETag')
       self.history[url] = etag
-      with open(FILE_HISTORY, 'w') as file2:
+      with open(FILE_HISTORY, 'w', encoding='utf-8') as file2:
         file2.write(json.dumps(self.history))
 
     elif req.status_code == 304:

--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -580,7 +580,7 @@ def _unflatten_satellite(flattened_measurement: Iterable[Row]) -> Iterator[Row]:
     combined.pop('measurement_id')
     # Remove extra tag fields from the measurement. These may be added
     # during the tagging step if a vantage point also appears as a response IP.
-    for tag in {'asname', 'asnum', 'http', 'cert'}:
+    for tag in ['asname', 'asnum', 'http', 'cert']:
       combined.pop(tag, None)
     yield combined
 

--- a/pipeline/metadata/test_blockpage.py
+++ b/pipeline/metadata/test_blockpage.py
@@ -80,7 +80,9 @@ class BlockpageTest(unittest.TestCase):
 
   def test_special_characters(self) -> None:
     matcher = blockpage.BlockpageMatcher()
+    # yapf: disable
     page = '''\u003chtml\u003e\r\n\u003chead\u003e\r\n\u003ctitle\u003eæ¡æç¶²é é»æ\u003c/title\u003e\r\n\u003cmeta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"\u003e\r\n\u003cMETA HTTP-EQUIV=\"PRAGMA\" CONTENT=\"NO-CACHE\"\u003e\r\n\u003cmeta name=\"viewport\" content=\"initial-scale=1.0\"\u003e\r\n\u003cstyle\u003e\r\n  #content {\r\n    border:3px solid#aaa;\r\n    background-color:#fff;\r\n    margin:1.5em;\r\n    padding:1.5em;\r\n    font-family:Tahoma,Helvetica,Arial,sans-serif;\r\n    font-size:1em;\r\n  }\r\n  h1 {\r\n    font-size:1.3em;\r\n    font-weight:bold;\r\n    color:#196390;\r\n  }\r\n  b {\r\n    font-weight:normal;\r\n    color:#196390;\r\n  }\r\n\u003c/style\u003e\r\n\u003c/head\u003e\r\n\u003cbody bgcolor=\"#e7e8e9\"\u003e\r\n\u003cdiv id=\"content\"\u003e\r\n\u003ch1\u003eéç¾è³è¨å®å¨é²è­· - æ¡æç¶²é é»æ\u003c/h1\u003e\r\n\u003cp\u003eå¦ææ¨çå°è©²ç«é¢è³è¨ï¼è¡¨ç¤ºæ¨è¢«å¤æ·å­åéæ­£å¸¸è¡çºç¶²ç« \u003cspan style=\"color:red;\"\u003e(æ¡æç¶²ç«)\u003c/span\u003e\u003c/p\u003e\r\n\u003cp\u003eè³è¨èª²å·²å°æ­¤ç¶²é é»æï¼å¦æç¢ºå®è©²ç¶²é æ¯è¢«èª¤å¤è«è¯ç¹«: éç¾è³è¨èª²-ç³»çµ±ç¶­éçµï¼è¬è¬ã\u003c/p\u003e\r\n\u003cp\u003e\u003cb\u003eä½¿ç¨è:\u003c/b\u003e 141.212.123.175 \u003c/p\u003e\r\n\u003cp\u003e\u003cb\u003eç¶²å:\u003c/b\u003e rtyutgyhefdafioasfjhjhi.com/ \u003c/p\u003e\r\n\u003cp\u003e\u003cb\u003eåé¡:\u003c/b\u003e command-and-control \u003c/p\u003e\r\n\u003c/div\u003e\r\n\u003c/body\u003e\r\n\u003c/html\u003e\r\n'''
+    # yapf: enable
     match, signature = matcher.match_page(page)
     self.assertTrue(match)
     self.assertEqual(signature, 'e_unk_style_red')
@@ -188,7 +190,9 @@ class BlockpageTest(unittest.TestCase):
     the overall pipeline to fail to complete. This test is designed to catch
     those regexes in case they're added in the future.
     """
-    page = open("pipeline/metadata/test_files/long_blockpage.html").read()
+    page = open(
+        "pipeline/metadata/test_files/long_blockpage.html",
+        encoding='utf-8').read()
     matcher = blockpage.BlockpageMatcher()
 
     start = time.perf_counter()
@@ -201,7 +205,9 @@ class BlockpageTest(unittest.TestCase):
   def test_long_blockpage(self) -> None:
     # This blockpage is a random long page take from the data.
     # It is ~65k, which is near the truncated limit.
-    page = open("pipeline/metadata/test_files/long_blockpage.html").read()
+    page = open(
+        "pipeline/metadata/test_files/long_blockpage.html",
+        encoding='utf-8').read()
     matcher = blockpage.BlockpageMatcher()
     # Page classification should be None
     # to ensure that it exercises all regexes in the performance test

--- a/table/run_queries.py
+++ b/table/run_queries.py
@@ -29,7 +29,7 @@ client = cloud_bigquery.Client(project=firehook_resources.PROJECT_NAME)
 
 
 def run_query(filepath: str) -> cloud_bigquery.table.RowIterator:
-  with open(filepath) as sql:
+  with open(filepath, encoding='utf-8') as sql:
     query_job = client.query(sql.read())
   return query_job.result()
 


### PR DESCRIPTION
The newly updated version of pylint has a few [new errors](https://github.com/censoredplanet/censoredplanet-analysis/pull/53/checks?check_run_id=3386637751). This fixes those so precommit checks succeed.