### PR TITLE
parameterize dataset names over the query

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-Install the dependencies with 
+Install the dependencies with
 
     pip install -r requirements.txt
 
@@ -61,6 +61,22 @@ If neither is specified the pipeline will automatically pick some reasonable
 dates to help avoid unintentially running test pipelines over large amounts of
 data. For appending pipelines this will be the latest week of data, and for
 full pipelines it will be the previous week of data.
+
+## Running queries
+
+After recreating the base tables you can rebuild any derived tables by running
+
+    python3 -m table.run_queries
+
+To test changes to the queries without overwriting the derived tables write to
+a personal dataset like
+
+    python3 -m table.run_queries --output=<username>
+
+If you want to read your own base tables (created from running a user pipeline
+above.) Then write the query as
+
+    python3 -m table.run_queries --input=<username> --output=<username>
 
 ## Access
 

--- a/table/run_queries.py
+++ b/table/run_queries.py
@@ -15,9 +15,10 @@
 
 Run as
 
-python3 tables/run_queries.py
+python3 -m table.run_queries
 """
 
+import argparse
 import glob
 from pprint import pprint
 
@@ -27,21 +28,48 @@ import firehook_resources
 
 client = cloud_bigquery.Client(project=firehook_resources.PROJECT_NAME)
 
+BASE_PLACEHOLDER = 'BASE_DATASET'
+DERIVED_PLACEHOLDER = 'DERIVED_DATASET'
 
-def run_query(filepath: str) -> cloud_bigquery.table.RowIterator:
+DEFAULT_BASE_DATASET = 'base'
+DEFAULT_DERIVED_DATASET = 'derived'
+
+
+def _run_query(filepath: str, base_dataset: str,
+               derived_dataset: str) -> cloud_bigquery.table.RowIterator:
   with open(filepath, encoding='utf-8') as sql:
-    query_job = client.query(sql.read())
+    query = sql.read()
+
+    query = query.replace(BASE_PLACEHOLDER, base_dataset)
+    query = query.replace(DERIVED_PLACEHOLDER, derived_dataset)
+
+    query_job = client.query(query)
   return query_job.result()
 
 
-def rebuild_all_tables() -> None:
+def rebuild_all_tables(base_dataset: str = DEFAULT_BASE_DATASET,
+                       derived_dataset: str = DEFAULT_DERIVED_DATASET) -> None:
   for filepath in glob.glob('table/queries/*.sql'):
     try:
-      run_query(filepath)
+      _run_query(filepath, base_dataset, derived_dataset)
     except Exception as ex:
       pprint(('Failed SQL query', filepath))
       raise ex
 
 
 if __name__ == '__main__':
-  rebuild_all_tables()
+  parser = argparse.ArgumentParser(description='Run a beam pipeline over scans')
+
+  parser.add_argument(
+      '--input',
+      type=str,
+      default=DEFAULT_BASE_DATASET,
+      help='Input dataset to query from')
+  parser.add_argument(
+      '--output',
+      type=str,
+      default=DEFAULT_DERIVED_DATASET,
+      help='Output dataset to write to')
+  args = parser.parse_args()
+
+  rebuild_all_tables(base_dataset=args.input, derived_dataset=args.output)


### PR DESCRIPTION
This makes it easier to write query results to a different table when developing without having to edit table names in the query.

The eventual goal here is to add running the query and testing the output table to the e2e test. But I wanted to get eyes on it before I wrote too much code.

I couldn't figure out a reasonable way to use `EXECUTE IMMEDIATE` without turning the query itself into a string.
https://stackoverflow.com/questions/59372469/create-table-using-a-variable-name-in-the-bigquery-ui But I'd like to find a less error-prone solution than the current basic string replace I have here. (While hopefully preserving sql syntax highlighting)