### PR TITLE
add missing cetegories for the most common domains

### DIFF
--- a/pipeline/metadata/data/domain_categories.csv
+++ b/pipeline/metadata/data/domain_categories.csv
@@ -6267,3 +6267,491 @@ b9good.com,Media sharing
 zone-telechargement1.org,Media sharing
 pridemedia.com,LGBT
 css-tricks.com,E-commerce
+about.riot.im,Communication Tools
+shadowsocks.org,Anonymization and circumvention tools
+freespeechdebate.com,Political Criticism
+icao.maps.arcgis.com,Intergovernmental Organizations
+en.miui.com,E-commerce
+livestream.com,Media sharing
+cdnjs.com,Hosting and Blogging Platforms
+www.bbm.com,Communication Tools
+www.ted.com,Media sharing
+www.health.com,Public Health
+www.shazam.com,Miscellaneous content
+www.f-list.net,Pornography
+www.pinkcupid.com,Online Dating
+www.sbs.com.au,News Media
+www.blockchain.com,E-commerce
+www.1800respect.org.au,Public Health
+www.zanzu.nl,Public Health
+www.genymotion.com,E-commerce
+www.overdrive.com,File-sharing
+www.infomigrants.net,News Media
+www.ushareit.com,File-sharing
+coronavirus.jhu.edu,Public Health
+europedatingonline.com,Online Dating
+help.unhcr.org,Intergovernmental Organizations
+www.monife.com,Online Dating
+www.tawk.to,Communication Tools
+web.archive.org,Media sharing
+www.occrp.org,News Media
+swift.org,E-commerce
+onlyfans.com,Pornography
+discord.com,Communication Tools
+nssac.bii.virginia.edu,Public Health
+ocsp.int-x3.letsencrypt.org,E-commerce
+www.gutenberg.org,History arts and literature
+letsencrypt.org,E-commerce
+theintercept.com,News Media
+eatthis.com,Public Health
+write.as,Hosting and Blogging Platforms
+censoredplanet.org,Human Rights Issues
+ocsp.comodoca.com,E-commerce
+www.americorps.gov,Government
+www.defenselink.mil,Government
+portal.hud.gov,Government
+www.northcom.mil,Government
+oea.gov,Government
+www.nga.mil,Government
+www.dla.mil,Government
+stats.bls.gov,Government
+www.chcoc.gov,Government
+www.frtib.gov,Government
+www.bpa.gov,Government
+www.dsca.mil,Government
+www.dss.mil,Government
+www.afrc.af.mil,Government
+www.doleta.gov,Government
+www.eucom.mil,Government
+www.armfor.uscourts.gov,Government
+www.hud.gov,Government
+www.health.mil,Government
+www.dol.gov,Government
+www.census.gov,Government
+www.huduser.org,Government
+www.dcma.mil,Government
+www.dcaa.mil,Government
+www.dfas.mil,Government
+www.cao.gov,Government
+www.dpaa.mil,Government
+www.dtra.mil,Government
+www.cffc.navy.mil,Government
+www.dau.mil,Government
+www.disa.mil,Government
+www.dtic.mil,Government
+www.pfpa.mil,Government
+www.jcs.mil,Government
+www.osha.gov,Government
+www.jpeocbrnd.osd.mil,Government
+www.jobcorps.gov,Government
+www.nationalguard.mil,Government
+www.nro.gov,Government
+www.nationalservice.gov,Government
+www.osmre.gov,Government
+www.swpa.gov,Government
+www.sss.gov,Government
+www.usmc.mil,Government
+www.ustranscom.mil,Government
+www.whs.mil,Government
+www.usuhs.mil,Government
+shopee.co.th,E-commerce
+haosou.com,Search Engines
+iweihai.cn,Communication Tools
+kontan.co.id,News Media
+doordash.com,E-commerce
+hbomax.com,Media sharing
+thegatewaypundit.com,News Media
+iqbroker.com,E-commerce
+videocampaign.co,Media sharing
+samizdat.is,Anonymization and circumvention tools
+mydramalist.com,News Media
+raseef22-net.cdn.ampproject.org,News Media
+raseef22.net,News Media
+www.madamasr.com,News Media
+wplay.co,Gambling
+jotform.com,E-commerce
+realestate.com.au,E-commerce
+linktr.ee,Media sharing
+tdameritrade.com,E-commerce
+agacelebir.com,Hacking Tools
+saednews.com,News Media
+app.wire.com,Communication Tools
+tanzil.net,Religion
+family.cloudflare-dns.com,Anonymization and circumvention tools
+safervpn.com,Anonymization and circumvention tools
+doh.dns.sb,Anonymization and circumvention tools
+doh.opendns.com,Anonymization and circumvention tools
+mozilla.cloudflare-dns.com,Anonymization and circumvention tools
+quran.com,Religion
+i2pforum.net,Anonymization and circumvention tools
+web.telegram.org,Communication Tools
+www.tiktok.com,Social Networking
+tx.me,Communication Tools
+telegra.ph,Hosting and Blogging Platforms
+surfshark.com,Anonymization and circumvention tools
+ajax.aspnetcdn.com,Hosting and Blogging Platforms
+telegram.me,Communication Tools
+tamtam.chat,Communication Tools
+download.i2p2.de,Anonymization and circumvention tools
+wire.com,Communication Tools
+ecer.com,E-commerce
+www.startmail.com,Communication Tools
+espiv.net,Hosting and Blogging Platforms
+espivblogs.net,Hosting and Blogging Platforms
+eghtesadonline.com,News Media
+makeamazonpay.com,Human Rights Issues
+www.globalpride2020.org,LGBT
+www.wechat.com,Communication Tools
+muwire.com,File-sharing
+ooni.org,Anonymization and circumvention tools
+play.google.com,E-commerce
+aajtak.in,News Media
+apps.apple.com,E-commerce
+pearson.com,E-commerce
+mytheresa.com,E-commerce
+eqxiu.com,Media sharing
+onmarshtompor.com,Hacking Tools
+onlinesbi.sbi,E-commerce
+get-express-vpn.online,Anonymization and circumvention tools
+shopee.ph,E-commerce
+miro.com,E-commerce
+emalls.ir,E-commerce
+cvs.com,E-commerce
+www.namecoin.org,E-commerce
+endclothing.com,E-commerce
+a8.net,E-commerce
+etoro.com,E-commerce
+vrbo.com,E-commerce
+oraclecloud.com,E-commerce
+hola.org,Anonymization and circumvention tools
+securevpn.com,Anonymization and circumvention tools
+upload.wikimedia.org,E-commerce
+premierbet.co.ao,Gambling
+nordvpn.com,Anonymization and circumvention tools
+securevpn.im,Anonymization and circumvention tools
+speedify.com,Anonymization and circumvention tools
+www.f-secure.com,E-commerce
+thunder.free-signal.com,Anonymization and circumvention tools
+www.lightsailvpn.com,Anonymization and circumvention tools
+manage.wix.com,Hosting and Blogging Platforms
+www.joinclubhouse.com,Social Networking
+stocktwits.com,E-commerce
+greenhost.net,Hosting and Blogging Platforms
+doh.centraleu.pi-dns.com,Anonymization and circumvention tools
+prtimes.jp,News Media
+mercadolibre.com,E-commerce
+cj.com,E-commerce
+eluniverso.com,News Media
+www.cfr.org,Government
+cra-arc.gc.ca,Government
+rahavard365.com,E-commerce
+tv9marathi.com,News Media
+yt1s.com,File-sharing
+windowsazure.com,E-commerce
+quillbot.com,E-commerce
+ebrun.com,E-commerce
+bestlifeonline.com,News Media
+coingecko.com,E-commerce
+symbolab.com,E-commerce
+cima4u.io,Media sharing
+seesaw.me,E-commerce
+statcounter.com,E-commerce
+ccaonline.cn,News Media
+lyst.com,E-commerce
+ribunews.com,Hacking Tools
+shareasale.com,E-commerce
+weixinyunduan.com,E-commerce
+www.trendsmap.com,E-commerce
+aporasal.net,E-commerce
+nobitex.ir,E-commerce
+desmos.com,E-commerce
+gogoanime.ai,Media sharing
+inews.id,News Media
+shopee.sg,E-commerce
+crowdworks.jp,E-commerce
+shippingchina.com,E-commerce
+cfsbcn.com,News Media
+cloudconvert.com,E-commerce
+zingnews.vn,News Media
+ecv360.com,News Media
+hangseng.com,E-commerce
+mosalasonline.com,News Media
+fiaharam.net,E-commerce
+dl.google.com,Search Engines
+blog.mozilla.org,Communication Tools
+api.github.com,E-commerce
+download-installer.cdn.mozilla.net,Communication Tools
+docs.github.com,E-commerce
+codeload.github.com,E-commerce
+u.gg,Gaming
+gist.github.com,E-commerce
+hops.id,News Media
+static.xx.fbcdn.net,Social Networking
+git.io,E-commerce
+cdn.sstatic.net,Hosting and Blogging Platforms
+www.clubhouseapi.com,Social Networking
+code.jquery.com,E-commerce
+fril.jp,E-commerce
+raw.githubusercontent.com,E-commerce
+scontent-ams4-1.cdninstagram.com,Social Networking
+ooni.github.io,Anonymization and circumvention tools
+visitbeijing.com.cn,E-commerce
+cowin.gov.in,Government
+amazon.sa,E-commerce
+www.wikidata.org,E-commerce
+52pk.com,Gambling
+arzdigital.com,E-commerce
+tv9telugu.com,News Media
+brainly.co.id,E-commerce
+intipseleb.com,News Media
+mmload.com,News Media
+houzz.com,E-commerce
+sba.gov,Government
+opensea.io,E-commerce
+guru99.com,E-commerce
+cnad.com,News Media
+digiato.com,News Media
+haraj.com.sa,E-commerce
+rasadeghtesadi.com,News Media
+wpengine.com,Hosting and Blogging Platforms
+tutsplus.com,E-commerce
+bitexworld.com,E-commerce
+atharori.net,E-commerce
+gogoanime.so,Media sharing
+mihoyo.com,Gaming
+tinkoff.ru,E-commerce
+worksmobile.com,E-commerce
+shopbop.com,E-commerce
+huamu.cn,E-commerce
+dns.adguard.com,Anonymization and circumvention tools
+binomo-webtrade.com,E-commerce
+eikegolehem.com,Hacking Tools
+semrush.com,E-commerce
+experian.com,E-commerce
+substack.com,E-commerce
+btctrademart.com,E-commerce
+business.com.tm,News Media
+doctolib.fr,Public Health
+shopstyle.com,E-commerce
+haibunda.com,Public Health
+wise.com,E-commerce
+juntadeandalucia.es,Government
+iloveimg.com,Media sharing
+woocommerce.com,E-commerce
+cretgate.com,Pornography
+wordcounter.net,Miscellaneous content
+b2b168.com,E-commerce
+linguee.com,Miscellaneous content
+uniswap.org,E-commerce
+byjus.com,E-commerce
+coindesk.com,E-commerce
+wrike.com,E-commerce
+ameli.fr,Public Health
+guifun.com,E-commerce
+gate.io,E-commerce
+report.az,News Media
+rediffmailpro.com,Communication Tools
+cima4u.ws,Media sharing
+placeit.net,E-commerce
+ringcentral.com,Communication Tools
+pancakeswap.finance,E-commerce
+61ef.cn,E-commerce
+shahed4u.onl,Media sharing
+webflow.com,E-commerce
+hindnow.com,News Media
+gdanstum.net,E-commerce
+cuevana3.io,Media sharing
+brave.com,Communication Tools
+lawtime.cn,Search Engines
+search.brave.com,Search Engines
+inb.network,E-commerce
+elementor.com,Hosting and Blogging Platforms
+cyol.com,News Media
+rsafrwd.com,Hacking Tools
+rencaijob.com,Search Engines
+sahamyab.com,E-commerce
+covid19india.org,Public Health
+xbytessolutions.com,E-commerce
+unilad.co.uk,News Media
+documentforce.com,E-commerce
+tap.az,E-commerce
+trknex.com,Miscellaneous content
+itpatratr.com,Hacking Tools
+9978.cn,E-commerce
+adf.ly,E-commerce
+goldcarpet.cn,E-commerce
+flipboard.com,News Media
+insertlive.com,E-commerce
+appsumo.com,E-commerce
+kinsta.com,Hosting and Blogging Platforms
+getresponse.com,E-commerce
+szu.edu.cn,E-commerce
+jnu.edu.cn,E-commerce
+apple.com.cn,E-commerce
+elegantthemes.com,Hosting and Blogging Platforms
+regecish.net,E-commerce
+au79nt5wic4x.com,Hacking Tools
+mercadolibre.cl,E-commerce
+alayam24.com,News Media
+atavatan-turkmenistan.com,News Media
+ems.com.cn,E-commerce
+abdurantom.com,Hacking Tools
+ynet.com,News Media
+www.gov.br,Government
+asmag.com.cn,E-commerce
+xtx6.com,E-commerce
+warriorplus.com,E-commerce
+rasadvarzeshi.com,News Media
+ahrefs.com,E-commerce
+star-clicks.com,E-commerce
+teamwork.com,E-commerce
+exe.app,Miscellaneous content
+fotor.com,Media sharing
+domaintools.com,E-commerce
+tmtpost.com,News Media
+ampugi334f.com,Miscellaneous content
+z3dmbpl6309s.com,Hacking Tools
+sendinblue.com,E-commerce
+core.ac.uk,Search Engines
+huobi.com,E-commerce
+prnewswire.com,News Media
+thinkific.com,E-commerce
+qafqazinfo.az,News Media
+amazon.jobs,E-commerce
+worldoftanks.eu,Gaming
+bestaryua.com,Hacking Tools
+okex.com,E-commerce
+jhu.edu,E-commerce
+365jia.cn,News Media
+yaklass.ru,E-commerce
+index-education.net,E-commerce
+webull.com,E-commerce
+china-ef.com,E-commerce
+airtm.com,E-commerce
+nbatopshot.com,E-commerce
+cryptotabbrowser.com,E-commerce
+jobkorea.co.kr,E-commerce
+huajiarui.com.cn,E-commerce
+payeer.com,E-commerce
+cairo24.com,News Media
+1stepdownload.com,File-sharing
+demotrader.org,E-commerce
+calendly.com,E-commerce
+brainly.lat,E-commerce
+ubereats.com,E-commerce
+successfactors.eu,E-commerce
+kommersant.ru,News Media
+hurirk.net,E-commerce
+pluralsight.com,E-commerce
+int.soccerway.com,News Media
+lbank.info,E-commerce
+3isk.video,Media sharing
+tvphapluat.vn,Media sharing
+streamyard.com,Media sharing
+tiaomu.com,E-commerce
+5acbd.com,E-commerce
+almaghreb24.com,News Media
+indodax.com,E-commerce
+adblockplus.org,Communication Tools
+laroza.net,Media sharing
+shahid4u.land,Media sharing
+cars.com,E-commerce
+playvalorant.com,Gaming
+pdf2go.com,Miscellaneous content
+redgifs.com,Media sharing
+nicehash.com,E-commerce
+daftsex.com,Pornography
+addtoany.com,Social Networking
+grubhub.com,E-commerce
+cjf25jklrwqt.com,Hacking Tools
+egybest.co,Media sharing
+scoutdealingdrift.com,Hacking Tools
+cnr.cn,News Media
+twilio.com,E-commerce
+crowd1.com,E-commerce
+example.com,Miscellaneous content
+download-ready.com,Miscellaneous content
+fsalfrwdr.com,Hacking Tools
+video-adblock.com,E-commerce
+virtual.edu.az,E-commerce
+itopvpn.com,Anonymization and circumvention tools
+e-sosial.az,Government
+afzhan.com,News Media
+keywordtool.io,E-commerce
+apa.az,News Media
+sciencehr.net,Search Engines
+uspto.gov,Government
+animevnn.com,Media sharing
+downloadspeedinfo.com,Miscellaneous content
+hellosign.com,E-commerce
+bancobai.ao,E-commerce
+iau.ac.ir,E-commerce
+postermywall.com,E-commerce
+net-a-porter.com,E-commerce
+zop381q5o0q1.com,Hacking Tools
+homes.co.jp,E-commerce
+baixarfilmetorrent.net,Media sharing
+draken.tech,E-commerce
+secnews.gr,News Media
+brainly.in,E-commerce
+mailerlite.com,Communication Tools
+binance.us,E-commerce
+pinterest.com.mx,Social Networking
+trthaber.com,News Media
+bbom2b434493.com,Hacking Tools
+pandadoc.com,E-commerce
+teambition.com,E-commerce
+khabarpu.com,News Media
+esheeq.net,Media sharing
+onizatop.net,E-commerce
+cupidrecession.com,Hacking Tools
+bscscan.com,E-commerce
+odoo.com,E-commerce
+sony.com,E-commerce
+gotjobbs.com,E-commerce
+prakerja.go.id,E-commerce
+exchain.ai,E-commerce
+pingdom.com,E-commerce
+blockskipad.com,E-commerce
+workable.com,E-commerce
+draken.exchange,E-commerce
+zdf.de,Media sharing
+91boshi.net,Search Engines
+upstox.com,E-commerce
+elmostaqbal.com,News Media
+dev.to,E-commerce
+binomo-trader.com,E-commerce
+sq.cn,E-commerce
+web.dev,E-commerce
+mostaghelonline.com,News Media
+bitchute.com,E-commerce
+freshannouncement.com,E-commerce
+skillshare.com,E-commerce
+download-now.org,E-commerce
+chinnica.net,E-commerce
+parler.com,Social Networking
+iiprpq1bsedg.com,Hacking Tools
+thehugejournal.com,Hacking Tools
+510hr.com,Miscellaneous content
+cima4u.live,Media sharing
+admitad.com,E-commerce
+csdiran.com,Media sharing
+vidstream.online,Media sharing
+w3.org,E-commerce
+yinyuetai.com,Media sharing
+eavesdroppingsickleemotionally.com,Hacking Tools
+heraldodemexico.com.mx,News Media
+houxue.com,E-commerce
+pendareghtesadi.com,News Media
+freshbooks.com,E-commerce
+edunet.net,E-commerce
+100zp.com,Search Engines
+goodhousekeeping.com,News Media
+cic.gc.ca,Government
+poshukach.com,Search Engines
+myactualblog.com,E-commerce
+gab.com,Social Networking
+jqk72ugyl2pz.com,Hacking Tools
+video-ad-skipper.com,E-commerce
+nta1vb6cdlrl.com,Hacking Tools
+gumroad.com,E-commerce


### PR DESCRIPTION
Added missing categories for domains that are the most common according to https://github.com/censoredplanet/jigsaw-cp-tracker/issues/11#issuecomment-905018208.

From running through these we could use some more categories. Ecommerce is doing way too much. It could easily be broken into:
- Tech
- Internet Infrastructure (dns servers, etc)
- Education
- Cryptocurrencies
- Regular (non-e) commerce
- Link referral sites / url shorteners

It would also be nice to have a specific malware command-and-control category.

But all of that's for future work. For now this will improve coverage.