### PR TITLE
Merge ASN and organization

### DIFF
--- a/docs/merged_reduced_scans_table.md
+++ b/docs/merged_reduced_scans_table.md
@@ -25,7 +25,7 @@ Reduced Scans
 | source       | STRING    | What probe type the measurement came from ("HTTPS", "HTTP", "DISCARD", "ECHO") |
 | domain     | STRING  | The domain being tested (eg. `example.com`) or `CONTROL` for control measurements |
 | category   | STRING  | The [category](domain_categories.md) of the domain being tested, eg. `Social Networking`, `None` if unknown |
-| country_name    | STRING  | The country of the autonomous system, eg. `US`  |
+| country_name    | STRING  | The country of the autonomous system, eg. `United States`  |
 | network        | STRING | The Autonomous System long name, eg. `Cloudflare, Inc.` |
 | subnetwork | STRING | The combinarion of the AS number and the IP organization, e.g. `AS6697 - Reliable Software, Ltd` |
 | outcome    | STRING  | An outcome classification, explained below. eg `read/timeout` |

--- a/docs/merged_reduced_scans_table.md
+++ b/docs/merged_reduced_scans_table.md
@@ -1,34 +1,19 @@
 # Reduced Table
 
-This table is actually a view joining two tables, in order to read over less
-data with every request.
+The table `firehook-censoredplanet.derived.merged_reduced_scans` contains filtered and pre-aggregated
+data to be used in the Censored Planet dashboard.
 
-These tables are created by the script
+The table is created by the script
 [merged_reduced_scans.sql](../table/queries/merged_reduced_scans.sql).
-
-## Table names
-
-### View
-
-- firehook-censoredplanet.derived.merged_reduced_scans
-
-### Sub-tables
-
-- `firehook-censoredplanet.derived.merged_reduced_scans_no_as`
-- `firehook-censoredplanet.derived.merged_net_as`
-
-These two tables are joined on their `date` and `netblock` fields to create the
-view.
 
 ## Partitioning and Clustering
 
-The sub-tables are time-partitioned along the `date` field.
+The table is [time-partitioned](https://cloud.google.com/bigquery/docs/partitioned-tables) along the `date` field.
+This allows queries to skip any data outside the desired date range.
 
-`firehook-censoredplanet.merged_reduced_scans` is clustered along the `netblock`
-field.
-
-`firehook-censoredplanet.merged_net_as` is clustered along the `country`,
-`category`, `domain` and then `netblock` fields.
+The table also uses [clustering](https://cloud.google.com/bigquery/docs/clustered-tables) to make filtering and aggregation
+more efficient. The table is clustered along the `source`, `country_name`, `network` and `domain` columns.
+The columns `source` and `country_name` are always used for filtering, so they come first.
 
 ## Table Format
 
@@ -37,15 +22,15 @@ Reduced Scans
 | Field Name | Type    | Contains |
 | ---------- | ------- | -------- |
 | date       | DATE    | Date that an individual measurement was taken |
-| domain     | STRING  | The domain being tested, eg. `example.com` |
+| source       | STRING    | What probe type the measurement came from ("HTTPS", "HTTP", "DISCARD", "ECHO") |
+| domain     | STRING  | The domain being tested (eg. `example.com`) or `CONTROL` for control measurements |
 | category   | STRING  | The [category](domain_categories.md) of the domain being tested, eg. `Social Networking`, `None` if unknown |
-| country    | STRING  | Autonomous system country, eg. `US`  |
-| netblock   | STRING  | Netblock of the IP, eg. `1.1.1.0/24`  |
-| asn        | INTEGER | Autonomous system number, eg. `13335` |
-| as_name    | STRING  | Autonomous system long name, eg. `Cloudflare, Inc.` |
-| result     | STRING  | `null` (meaning success) or error returned. eg. `Incorrect web response: status lines don't match`. Errors come either from the probe system, or directly from [Go's net package](https://golang.org/pkg/net/) |
+| country_name    | STRING  | The country of the autonomous system, eg. `US`  |
+| network        | STRING | The Autonomous System long name, eg. `Cloudflare, Inc.` |
+| subnetwork | STRING | The combinarion of the AS number and the IP organization, e.g. `AS6697 - Reliable Software, Ltd` |
 | outcome    | STRING  | An outcome classification, explained below. eg `read/timeout` |
 | count      | INTEGER | How many measurements fit the exact pattern of this row? |
+| unexpected_count      | INTEGER | Count of measurements with an unexpected outcome |
 
 ## Outcome Classification
 

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -112,7 +112,13 @@ CREATE TEMP FUNCTION ClassifyError(error STRING,
 
 CREATE OR REPLACE TABLE `firehook-censoredplanet.DERIVED_DATASET.merged_reduced_scans`
 PARTITION BY date
+# Columns `source` and `country_name` are always used for filtering and must come first.
+# `network` and `domain` are useful for filtering and grouping.
 CLUSTER BY source, country_name, network, domain
+OPTIONS (
+  friendly_name="Reduced Scans",
+  description="Filtered and pre-aggregated table of scans to use with the Censored Planed Dashboard"
+)
 AS (
 WITH AllScans AS (
   SELECT * except (source), "DISCARD" AS source

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -12,15 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CREATE TEMP FUNCTION CleanError(error STRING) AS (
-  REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(
-    IF(error = "", "null", IFNULL(error, "null")),
-    "[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+", "[IP]"),
-    "\\[IP\\]:[0-9]+", "[IP]:[PORT]"),
-    "length [0-9]+", "length [LENGTH]"),
-    "port\\.[0-9]+", "port.[PORT]")
-);
-
 # Classify all errors into a small set of enums
 #
 # Input is a nullable error string from the raw data
@@ -168,8 +159,3 @@ SELECT
     FROM Grouped
     LEFT JOIN `firehook-censoredplanet.metadata.country_names` using (country_code)
 );
-
-# Drop the temp function before creating the view
-# Since any temp functions in scope block view creation.
-DROP FUNCTION CleanError;
-DROP FUNCTION ClassifyError;

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -119,7 +119,7 @@ CREATE TEMP FUNCTION ClassifyError(error STRING,
 # BASE_DATASET and DERIVED_DATASET are reserved dataset placeholder names
 # which will be replaced when running the query
 
-CREATE OR REPLACE TABLE `firehook-censoredplanet.DERIVED_DATASET.merged_reduced_scans_no_as`
+CREATE OR REPLACE TABLE `firehook-censoredplanet.DERIVED_DATASET.merged_reduced_scans`
 PARTITION BY date
 CLUSTER BY source, country_name, network, domain
 AS (
@@ -150,10 +150,10 @@ WITH AllScans AS (
 
         count(*) as count
     FROM AllScans
-    # Filter it here so that we don't need to load the outcome to apply the report filtering on every filter.
-    WHERE
-        NOT controls_failed
+    # Filter on controls_failed to potentially reduce the number of output rows (less dimensions to group by).
+    WHERE NOT controls_failed
     GROUP BY date, source, country_code, network, outcome, domain, category, subnetwork
+    # Filter it here so that we don't need to load the outcome to apply the report filtering on every filter.
     HAVING NOT STARTS_WITH(outcome, "setup/")
 )
 SELECT


### PR DESCRIPTION
1) This PR merges ASN and organization into a single field called `subnetwork`.
The `as_name` is now called `network`.

This addresses the many layers of nesting in the UI. We can now expose both the ASes and the IP org on the main pivot table:
![image](https://user-images.githubusercontent.com/113565/131162223-331051df-9731-448a-878e-d42a4e1bcbf2.png)

This was only possible by removing the query-time join. `mesged_reduced_scans` is now a materialized table, not a view

2) I moved the calculation of the `unexpected_count` to the offline query. This way we won't need to read and process the outcome to generate the main pivot table in the dashboard.

3) I moved the `controls_failed` test to the offline query and removed the column. I don't think it gives us much gain, so I could be convinced to keep it. 

3) I removed the `results` column, which was not being used. That makes the offline query significantly cheaper. I got from ~15min to ~10min, though I'm not sure I trust those numbers. I did see that it spends a lot of compute time in the stage of the error cleaning.

4) I removed `netblock`. It doesn't seem useful anymore. This helps reduce the number of rows in the grouped table (from 16B to 11B). I could add it back, but I don't really think it's that meaningful to users. We now have 2 layers of network dimensions, instead of 4.

5) I refactored the query to avoid the duplication that was happening for each source

The original `merged_scans_no_as` is 1.94TB with 16.9B rows. The new `merged_reduced_scans` is 1.47TB with 11.1B rows.

/cc @ramakrishnansr @avirkud 