### PR TITLE
streamline outcome names

### DIFF
--- a/docs/merged_reduced_scans_table.md
+++ b/docs/merged_reduced_scans_table.md
@@ -101,10 +101,10 @@ Mismatch Errors are used when the connection is successful, but the content rece
 | http.empty              | Received no content when HTTP content was expected |
 | http.truncated_response | The HTTP response content was unexpectedly truncated |
 |                         |
-| **Unexpected Content**  | The connection completed successfully, but the content returned didn't match the content expected for the domain. |
+| **Mismatched Content**  | The connection completed successfully, but the content returned didn't match the content expected for the domain. |
 |                         |
-| unexpected              | Received a different response from the one expected. </br> For Discard no response is expected and any response is a mismatch, </br> for Echo a mirrored response is expected and anything else is a mismatch. </br> For HTTP/S the expected response is determined by sending multiple control domains to the server and building an expected template. This response is returned when more detail about the exact part of the template mismatched (eg. status, body) is not available. |
-| unexpected_status       | The HTTP status code didn't match, eg. `403` instead of `200` |
-| unexpected_body         | The HTTP body didn't match, potentially a blockpage |
-| unexpected_tls          | An element of the TLS connection (certificate, cipher suite, or TLS version) didn't match |
+| mismatch                | Received a different response from the one expected. </br> For Discard no response is expected and any response is a mismatch, </br> for Echo a mirrored response is expected and anything else is a mismatch. </br> For HTTP/S the expected response is determined by sending multiple control domains to the server and building an expected template. This response is returned when more detail about the exact part of the template mismatched (eg. status, body) is not available. |
+| status_mismatch         | The HTTP status code didn't match, eg. `403` instead of `200` |
+| body_mismatch           | The HTTP body didn't match, potentially a blockpage |
+| tls_mismatch            | An element of the TLS connection (certificate, cipher suite, or TLS version) didn't match |
 | blockpage               | The response was unexpected and matched a [known blockpage]((https://github.com/censoredplanet/censoredplanet-analysis/blob/master/pipeline/metadata/data/blockpage_signatures.json)) |

--- a/docs/merged_reduced_scans_table.md
+++ b/docs/merged_reduced_scans_table.md
@@ -19,18 +19,18 @@ The columns `source` and `country_name` are always used for filtering, so they c
 
 Reduced Scans
 
-| Field Name | Type    | Contains |
-| ---------- | ------- | -------- |
-| date       | DATE    | Date that an individual measurement was taken |
-| source       | STRING    | What probe type the measurement came from ("HTTPS", "HTTP", "DISCARD", "ECHO") |
-| domain     | STRING  | The domain being tested (eg. `example.com`) or `CONTROL` for control measurements |
-| category   | STRING  | The [category](domain_categories.md) of the domain being tested, eg. `Social Networking`, `None` if unknown |
-| country_name    | STRING  | The country of the autonomous system, eg. `United States`  |
-| network        | STRING | The Autonomous System long name, eg. `Cloudflare, Inc.` |
-| subnetwork | STRING | The combinarion of the AS number and the IP organization, e.g. `AS6697 - Reliable Software, Ltd` |
-| outcome    | STRING  | An outcome classification, explained below. eg `read/timeout` |
-| count      | INTEGER | How many measurements fit the exact pattern of this row? |
-| unexpected_count      | INTEGER | Count of measurements with an unexpected outcome |
+| Field Name       | Type    | Contains |
+| ---------------- | ------- | -------- |
+| date             | DATE    | Date that an individual measurement was taken |
+| source           | STRING  | What probe type the measurement came from ("HTTPS", "HTTP", "DISCARD", "ECHO") |
+| domain           | STRING  | The domain being tested (eg. `example.com`) or `CONTROL` for control measurements |
+| category         | STRING  | The [category](domain_categories.md) of the domain being tested, eg. `Social Networking`, `None` if unknown |
+| country_name     | STRING  | The country of the autonomous system, eg. `United States`  |
+| network          | STRING  | The Autonomous System long name, eg. `China Telecom` |
+| subnetwork       | STRING  | The combination of the AS number and the IP organization. The subnetworks can represent multiple autonomous systems owned by a single organization. They can also show IP space which has been sub-leased from one organization to another. e.g. `AS4812 - Apple technology services (Shanghai) Co., Ltd.` which represents IP space sub-leased from `China Telecom`'s network `AS4812` |
+| outcome          | STRING  | An outcome classification, explained below. eg `read/timeout` |
+| count            | INTEGER | How many measurements fit the exact pattern of this row? |
+| unexpected_count | INTEGER | Count of measurements with an unexpected outcome |
 
 ## Outcome Classification
 
@@ -101,13 +101,10 @@ Mismatch Errors are used when the connection is successful, but the content rece
 | http.empty              | Received no content when HTTP content was expected |
 | http.truncated_response | The HTTP response content was unexpectedly truncated |
 |                         |
-| **Mismatch Errors**     | The connection completed successfully, but the content returned didn't match the content expected for the domain. |
+| **Unexpected Content**  | The connection completed successfully, but the content returned didn't match the content expected for the domain. |
 |                         |
-| HyperQuack v1 only      |
-| response_mismatch       | Received a different response from the one expected. </br> For Discard no response is expected and any response is a mismatch, </br> for Echo a mirrored response is expected and anything else is a mismatch. |
-| status_mismatch         | The HTTP status code didn't match, eg. `403` instead of `200` |
-| body_mismatch           | The HTTP body didn't match, potentially a blockpage |
-| tls_mismatch            | An element of the TLS connection (certificate, cipher suite, or TLS version) didn't match |
-| HyperQuack v1 and v2    |
-| template_mismatch       | Some element of the response did not match the expected template |
+| unexpected              | Received a different response from the one expected. </br> For Discard no response is expected and any response is a mismatch, </br> for Echo a mirrored response is expected and anything else is a mismatch. </br> For HTTP/S the expected response is determined by sending multiple control domains to the server and building an expected template. This response is returned when more detail about the exact part of the template mismatched (eg. status, body) is not available. |
+| unexpected_status       | The HTTP status code didn't match, eg. `403` instead of `200` |
+| unexpected_body         | The HTTP body didn't match, potentially a blockpage |
+| unexpected_tls          | An element of the TLS connection (certificate, cipher suite, or TLS version) didn't match |
 | blockpage               | The response was unexpected and matched a [known blockpage]((https://github.com/censoredplanet/censoredplanet-analysis/blob/master/pipeline/metadata/data/blockpage_signatures.json)) |

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -30,7 +30,7 @@ CREATE TEMP FUNCTION ClassifyError(error STRING,
 
     # Content mismatch for hyperquack v2 which didn't write
     # content verification failures in the error field from 2021-04-26 to 2021-07-21
-    WHEN (NOT template_match AND (error is NULL OR error = "")) then "content/unexpected"
+    WHEN (NOT template_match AND (error is NULL OR error = "")) then "content/mismatch"
 
     # Success
     WHEN (error is NULL OR error = "") then "complete/success"
@@ -84,23 +84,23 @@ CREATE TEMP FUNCTION ClassifyError(error STRING,
     WHEN REGEXP_CONTAINS(error, "malformed MIME") THEN "http/http.invalid"
 
     # Content verification failures
-    WHEN (source = "ECHO" AND ENDS_WITH(error, "EOF")) THEN "content/unexpected" # Echo
+    WHEN (source = "ECHO" AND ENDS_WITH(error, "EOF")) THEN "content/mismatch" # Echo
     # Hyperquack v1 errors
-    WHEN (error = "Incorrect echo response") THEN "content/unexpected" # Echo
-    WHEN (error = "Received response") THEN "content/unexpected" # Discard
-    WHEN (error = "Incorrect web response: status lines don't match") THEN "content/unexpected_status" # HTTP/S
-    WHEN (error = "Incorrect web response: bodies don't match") THEN "content/unexpected_body" # HTTP/S
-    WHEN (error = "Incorrect web response: certificates don't match") THEN "content/unexpected_tls" # HTTPS
-    WHEN (error = "Incorrect web response: cipher suites don't match") THEN "content/unexpected_tls" # HTTPS
-    WHEN (error = "Incorrect web response: TLS versions don't match") THEN "content/unexpected_tls" # HTTPS
+    WHEN (error = "Incorrect echo response") THEN "content/mismatch" # Echo
+    WHEN (error = "Received response") THEN "content/mismatch" # Discard
+    WHEN (error = "Incorrect web response: status lines don't match") THEN "content/status_mismatch" # HTTP/S
+    WHEN (error = "Incorrect web response: bodies don't match") THEN "content/body_mismatch" # HTTP/S
+    WHEN (error = "Incorrect web response: certificates don't match") THEN "content/tls_mismatch" # HTTPS
+    WHEN (error = "Incorrect web response: cipher suites don't match") THEN "content/tls_mismatch" # HTTPS
+    WHEN (error = "Incorrect web response: TLS versions don't match") THEN "content/tls_mismatch" # HTTPS
     # Hyperquack v2 errors
-    WHEN (error = "echo response does not match echo request") THEN "content/unexpected" # Echo
-    WHEN (error = "discard response is not empty") THEN "content/unexpected" # Discard
-    WHEN (error = "Status lines does not match") THEN "content/unexpected_status" # HTTP/S
-    WHEN (error = "Bodies do not match") THEN "content/unexpected_body" # HTTP/S
-    WHEN (error = "Certificates do not match") THEN "content/unexpected_tls" # HTTPS
-    WHEN (error = "Cipher suites do not match") THEN "content/unexpected_tls" # HTTPS
-    WHEN (error = "TLS versions do not match") THEN "content/unexpected_tls" # HTTPS
+    WHEN (error = "echo response does not match echo request") THEN "content/mismatch" # Echo
+    WHEN (error = "discard response is not empty") THEN "content/mismatch" # Discard
+    WHEN (error = "Status lines does not match") THEN "content/status_mismatch" # HTTP/S
+    WHEN (error = "Bodies do not match") THEN "content/body_mismatch" # HTTP/S
+    WHEN (error = "Certificates do not match") THEN "content/tls_mismatch" # HTTPS
+    WHEN (error = "Cipher suites do not match") THEN "content/tls_mismatch" # HTTPS
+    WHEN (error = "TLS versions do not match") THEN "content/tls_mismatch" # HTTPS
 
     # Unknown errors
     ELSE "unknown/unknown"

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -28,9 +28,9 @@ CREATE TEMP FUNCTION ClassifyError(error STRING,
   CASE
     WHEN blockpage_match then CONCAT("content/blockpage:", blockpage_id)
 
-    # Content mismatch for hyperquack v2 which doesn't write
-    # content verification failures in the error field.
-    WHEN (NOT template_match AND (error is NULL OR error = "")) then "content/template_mismatch"
+    # Content mismatch for hyperquack v2 which didn't write
+    # content verification failures in the error field from 2021-04-26 to 2021-07-21
+    WHEN (NOT template_match AND (error is NULL OR error = "")) then "content/unexpected"
 
     # Success
     WHEN (error is NULL OR error = "") then "complete/success"
@@ -84,23 +84,23 @@ CREATE TEMP FUNCTION ClassifyError(error STRING,
     WHEN REGEXP_CONTAINS(error, "malformed MIME") THEN "http/http.invalid"
 
     # Content verification failures
-    WHEN (source = "ECHO" AND ENDS_WITH(error, "EOF")) THEN "content/response_mismatch" # Echo
+    WHEN (source = "ECHO" AND ENDS_WITH(error, "EOF")) THEN "content/unexpected" # Echo
     # Hyperquack v1 errors
-    WHEN (error = "Incorrect echo response") THEN "content/response_mismatch" # Echo
-    WHEN (error = "Received response") THEN "content/response_mismatch" # Discard
-    WHEN (error = "Incorrect web response: status lines don't match") THEN "content/status_mismatch" # HTTP/S
-    WHEN (error = "Incorrect web response: bodies don't match") THEN "content/body_mismatch" # HTTP/S
-    WHEN (error = "Incorrect web response: certificates don't match") THEN "content/tls_mismatch" # HTTPS
-    WHEN (error = "Incorrect web response: cipher suites don't match") THEN "content/tls_mismatch" # HTTPS
-    WHEN (error = "Incorrect web response: TLS versions don't match") THEN "content/tls_mismatch" # HTTPS
+    WHEN (error = "Incorrect echo response") THEN "content/unexpected" # Echo
+    WHEN (error = "Received response") THEN "content/unexpected" # Discard
+    WHEN (error = "Incorrect web response: status lines don't match") THEN "content/unexpected_status" # HTTP/S
+    WHEN (error = "Incorrect web response: bodies don't match") THEN "content/unexpected_body" # HTTP/S
+    WHEN (error = "Incorrect web response: certificates don't match") THEN "content/unexpected_tls" # HTTPS
+    WHEN (error = "Incorrect web response: cipher suites don't match") THEN "content/unexpected_tls" # HTTPS
+    WHEN (error = "Incorrect web response: TLS versions don't match") THEN "content/unexpected_tls" # HTTPS
     # Hyperquack v2 errors
-    WHEN (error = "echo response does not match echo request") THEN "content/response_mismatch" # Echo
-    WHEN (error = "discard response is not empty") THEN "content/response_mismatch" # Discard
-    WHEN (error = "Status lines does not match") THEN "content/status_mismatch" # HTTP/S
-    WHEN (error = "Bodies do not match") THEN "content/body_mismatch" # HTTP/S
-    WHEN (error = "Certificates do not match") THEN "content/tls_mismatch" # HTTPS
-    WHEN (error = "Cipher suites do not match") THEN "content/tls_mismatch" # HTTPS
-    WHEN (error = "TLS versions do not match") THEN "content/tls_mismatch" # HTTPS
+    WHEN (error = "echo response does not match echo request") THEN "content/unexpected" # Echo
+    WHEN (error = "discard response is not empty") THEN "content/unexpected" # Discard
+    WHEN (error = "Status lines does not match") THEN "content/unexpected_status" # HTTP/S
+    WHEN (error = "Bodies do not match") THEN "content/unexpected_body" # HTTP/S
+    WHEN (error = "Certificates do not match") THEN "content/unexpected_tls" # HTTPS
+    WHEN (error = "Cipher suites do not match") THEN "content/unexpected_tls" # HTTPS
+    WHEN (error = "TLS versions do not match") THEN "content/unexpected_tls" # HTTPS
 
     # Unknown errors
     ELSE "unknown/unknown"


### PR DESCRIPTION
Trying to make the mismatch error names clearer. Is there a clearer/more specific name we could use here than `mismatch` or `unexpected`?

- Echo, Discard, and HTTP/S (when we don't have more detail) all now use the same `content/mismatch` outcome. This will help the HTTP tab to have fewer different outcomes.
- HTTP/S (when more detail is available) use a longer string like `content/body_mismatch`. I think this helps make it more clear that `body_mismatch` results are a special case of general `unexpected` results.

Removed some Hyperquack v1/v2 distinctions in the documentation and tried to add more detail about when content is considered unexpected without getting too into the weeds.

Also tried to add a more representative examples for network/subnetwork.