### PR TITLE
filter measurements without countries

### DIFF
--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -169,6 +169,7 @@ SELECT
     END as unexpected_count
     FROM Grouped
     LEFT JOIN `firehook-censoredplanet.metadata.country_names` using (country_code)
+    WHERE country_code IS NOT NULL
 );
 
 # Drop the temp function before creating the view


### PR DESCRIPTION
Remove measurements which don't have a country.

If the country code is null it means we weren't able to get an AS/country for the IP from the CAIDA data. That's something we should fix in the pipeline, but it's meaningless to dashboard users and adds noise.

Currently we have 17mil measurements with null country codes (over all time) or .5% of the total data.