### PR TITLE
require output argument to be specified when running manual queries

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -66,7 +66,7 @@ full pipelines it will be the previous week of data.
 
 After recreating the base tables you can rebuild any derived tables by running
 
-    python3 -m table.run_queries
+    python3 -m table.run_queries --output=derived
 
 To test changes to the queries without overwriting the derived tables write to
 a personal dataset like

--- a/table/run_queries.py
+++ b/table/run_queries.py
@@ -68,8 +68,8 @@ if __name__ == '__main__':
   parser.add_argument(
       '--output',
       type=str,
-      default=DEFAULT_DERIVED_DATASET,
-      help='Output dataset to write to')
+      required=True,
+      help='Output dataset to write to. To write to prod use --output=derived')
   args = parser.parse_args()
 
   rebuild_all_tables(base_dataset=args.input, derived_dataset=args.output)


### PR DESCRIPTION
Require the `output` to be a specified argument when manually running the queries.

This will help avoid anyone overwriting the prod table by accident.

Tested:
> python3 -m table.run_queries
>
> usage: run_queries.py [-h] [--input INPUT] --output OUTPUT
> run_queries.py: error: the following arguments are required: --output