### PR TITLE
classify missing categories as uncategorized

### DIFF
--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -159,7 +159,7 @@ WITH AllScans AS (
 
         ClassifyError(error, source, success, blockpage, page_signature, ExtractServerHeader(received_headers)) AS outcome,
         CONCAT("AS", asn, IF(organization IS NOT NULL, CONCAT(" - ", organization), "")) AS subnetwork,
-        category,
+        IFNULL(category, "Uncategorized") AS category,
 
         COUNT(*) AS count
     FROM AllScans


### PR DESCRIPTION
Small UI fix. Currently we display missing domain categories as `null` in the dashboard, this will put them all under `Uncategorized`

![7HzDdS3zo2GuroX](https://user-images.githubusercontent.com/1127209/137029068-418c4154-9438-4384-8f7c-5f82c943d631.png)
