### PR TITLE
config changes to run a successful satellite backfill

### DIFF
--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -89,8 +89,8 @@ SCAN_TYPES_TO_ZONES = {
     'https': 'us-east1',  # https has the most data, so it gets the best zone.
     'http': 'us-east4',
     'echo': 'us-west1',
-    'discard': 'us-central1',
-    'satellite': 'us-west2'
+    'discard': 'us-west2',
+    'satellite': 'us-central1'  # us-central1 has 160 shuffle slots by default
 }
 
 ALL_SCAN_TYPES = SCAN_TYPES_TO_ZONES.keys()
@@ -527,7 +527,7 @@ class ScanDataBeamPipelineRunner():
         runtime_type_check=False,  # slow in prod
         experiments=[
             'enable_execution_details_collection',
-            'use_monitoring_state_manager'
+            'use_monitoring_state_manager', 'upload_graph'
         ],
         setup_file='./pipeline/setup.py')
     pipeline_options.view_as(SetupOptions).save_main_session = True


### PR DESCRIPTION
I was able to run a [successful backfill job](https://github.com/censoredplanet/jigsaw-cp-tracker/issues/9#issuecomment-965348058). 

These were the changes I had to make:
- using the experimental `upload_graph` option to get around the 10MB beam graph size limit
- Changing the default satellite region to `us-central1`, which has 160 shuffle slots by default (`us-west2` has 24). This stops the job from failing on heavy shuffle phases.