### PR TITLE
make filenames a pcollection instead of individual steps

### DIFF
--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -117,15 +117,22 @@ class PipelineMainTest(unittest.TestCase):
 
   def test_read_scan_text(self) -> None:  # pylint: disable=no-self-use
     """Test reading lines from compressed and uncompressed files"""
-    p = TestPipeline()
-    pipeline = beam_tables._read_scan_text(
-        p, ['pipeline/test_results_1.json', 'pipeline/test_results_2.json.gz'])
+    with TestPipeline() as p:
+      lines = beam_tables._read_scan_text(
+          p,
+          ['pipeline/test_results_1.json', 'pipeline/test_results_2.json.gz'])
 
-    beam_test_util.assert_that(
-        pipeline,
-        beam_test_util.equal_to([
-            'test line 1.1', 'test line 1.2', 'test line 2.1', 'test line 2.2'
-        ]))
+      # Due to some detail of how beam's test util works
+      # The test line strings here need to be double-quoted.
+      # The actual strings in the pipeline are not double-quoted.
+      expected = [
+          ('pipeline/test_results_1.json', '"test line 1.1"'),
+          ('pipeline/test_results_1.json', '"test line 1.2"'),
+          ('pipeline/test_results_2.json.gz', '"test line 2.1"'),
+          ('pipeline/test_results_2.json.gz', '"test line 2.2"'),
+      ]
+
+      beam_test_util.assert_that(lines, beam_test_util.equal_to(expected))
 
   def test_between_dates(self) -> None:
     """Test logic to include filenames based on their creation dates."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-apache-beam==2.25.0
-apache-beam[gcp]==2.25.0
+apache-beam==2.33.0
+apache-beam[gcp]==2.33.0
 freezegun==1.0.0
 # Maxmind
 geoip2==4.1.0


### PR DESCRIPTION
This massively cuts down on the amount of time it takes to start up jobs with hundreds/thousands of input files.

This is only recently simple because `ReadAllFromText` added the `with_filenames` option https://github.com/apache/beam/pull/15126 / https://issues.apache.org/jira/browse/BEAM-12665

Also fix `test_read_scan_text`, which was erroneously passing but not actually checking anything before.

PipelineManualE2eTest passed.

I'm going to hold off on merging this until I get a chance to run a full satellite backfill with it. (To make sure it doesn't cause fusion.) Currently I'm waiting so i don't interfere with a job @avirkud is running.