### PR TITLE
get weird of secret dates in user pipelines

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 apache-beam==2.33.0
 apache-beam[gcp]==2.33.0
-freezegun==1.0.0
 # Maxmind
 geoip2==4.1.0
 # Imports GCS client needed for beam


### PR DESCRIPTION
This removes the behavior where running `--env=user` pipelines would secretly only run over a week or two of data unless you explicitly specify the dates. The original intent for this was to avoid people processing excessive data in the dev pipelines unintentionally. But now we commonly run dev pipelines over the entire dataset and this behavior is just confusing.

Also kills off a bunch of tests that were checking this behavior.