### PR TITLE
change dev pipelines to specify dataset on command line

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -49,17 +49,20 @@ to side tables named after the username of the developer.
 
 To test a full data reload:
 
-    python -m pipeline.run_beam_tables --env=user --scan_type=http --full
+    python -m pipeline.run_beam_tables --env=user --user_dataset=<username> \
+    -scan_type=http --full
 
 To test an appending data reload. (This requires a table to already exist):
 
-    python -m pipeline.run_beam_tables --env=user --scan_type=http
+    python -m pipeline.run_beam_tables --env=user --user_dataset=<username> \
+    --scan_type=http
 
 Options for `scan_type` are `echo`, `discard`, `http`, `https` and `satellite`
 
 To test specific dates run a pipeline like
 
-   python -m pipeline.run_beam_tables --env=user --scan_type=http --start_date=2021-01-01 --end_date=2021-01-30
+    python -m pipeline.run_beam_tables --env=user --user_dataset=<username> \
+    --scan_type=http --start_date=2021-01-01 --end_date=2021-01-30
 
 If only `start_date` is specified the pipeline will run from that date until
 the latest data.

--- a/pipeline/test_run_beam_tables.py
+++ b/pipeline/test_run_beam_tables.py
@@ -14,7 +14,6 @@
 """Test top-level runner for beam pipelines."""
 
 import argparse
-from collections import namedtuple
 import datetime
 import unittest
 from unittest.mock import call, patch, MagicMock
@@ -87,8 +86,6 @@ class RunBeamTablesTest(unittest.TestCase):
       # No extra calls
       self.assertEqual(4, mock_runner.run_beam_pipeline.call_count)
 
-  @patch('pwd.getpwuid', lambda x: namedtuple('mock_uid', ['pw_name'])
-         ('laplante'))
   def test_main_user_dates(self) -> None:
     """Test arg parsing for a user pipeline with dates."""
     mock_runner = MagicMock(beam_tables.ScanDataBeamPipelineRunner)
@@ -99,6 +96,7 @@ class RunBeamTablesTest(unittest.TestCase):
           full=False,
           scan_type='echo',
           env='user',
+          user_dataset='laplante',
           start_date=datetime.date(2021, 1, 8),
           end_date=datetime.date(2021, 1, 15))
       run_beam_tables.main(args)


### PR DESCRIPTION
Getting usernames from the system was unnecessarily clever, and it seems like both of us have been having problems with running pipelines with the wrong username. This requires a simple command line specification instead.