### PR TITLE
make all satellite filenames variables

### DIFF
--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -383,7 +383,7 @@ class ScanDataBeamPipelineRunner():
       existing_sources = []
 
     if scan_type == satellite.SCAN_TYPE_SATELLITE:
-      files_to_load = satellite.SATELLITE_FILES
+      files_to_load = flatten.SATELLITE_FILES
     else:
       files_to_load = SCAN_FILES
 

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -67,15 +67,6 @@ BLOCKPAGE_BIGQUERY_SCHEMA = {
     'received_tls_cert': ('string', 'nullable'),
 }
 
-# Data files for the Satellite pipeline
-# Satellite v1 has several output files
-SATELLITE_FILES = [
-    'resolvers.json', 'tagged_resolvers.json', 'tagged_answers.json',
-    'answers_control.json', 'interference.json', 'interference_err.json',
-    'responses_control.json', 'tagged_responses.json', 'results.json',
-    'answers_err.json', 'blockpages.json'
-]
-
 SCAN_TYPE_SATELLITE = 'satellite'
 SCAN_TYPE_BLOCKPAGE = 'blockpage'
 
@@ -510,15 +501,18 @@ def partition_satellite_input(
     )
   filename = pathlib.PurePosixPath(line[0]).name
   if filename in [
-      'resolvers.json', 'tagged_resolvers.json', 'tagged_answers.json',
-      'tagged_responses.json'
+      flatten.SATELLITE_RESOLVERS_FILE, flatten.SATELLITE_TAGGED_RESOLVERS_FILE,
+      flatten.SATELLITE_TAGGED_ANSWERS_FILE, flatten.SATELLITE_TAGGED_RESPONSES
   ]:
     return 0
-  if filename in ['blockpages.json']:
+  if filename == flatten.SATELLITE_BLOCKPAGES_FILE:
     return 1
   if filename in [
-      'interference.json', 'interference_err.json', 'answers_control.json',
-      'responses_control.json', 'results.json', 'answers_err.json'
+      flatten.SATELLITE_INTERFERENCE_FILE,
+      flatten.SATELLITE_INTERFERENCE_ERR_FILE,
+      flatten.SATELLITE_ANSWERS_CONTROL_FILE,
+      flatten.SATELLITE_RESPONSES_CONTROL_FILE, flatten.SATELLITE_RESULTS_FILE,
+      flatten.SATELLITE_ANSWERS_ERR_FILE
   ]:
     return 2
   raise Exception(f"Unknown filename in Satellite data: {filename}")


### PR DESCRIPTION
Refactoring

Turn all the satellite filenames into variables and do all logic against those variables instead of defining the names in multiple places. This doesn't change any behavior, just make it harder to make a mistake in the future.