### PR TITLE
refactor get_category from flatten_base into DomainCategoryMatcher

### DIFF
--- a/pipeline/metadata/domain_categories.py
+++ b/pipeline/metadata/domain_categories.py
@@ -66,19 +66,25 @@ def _load_categories(filepath: str) -> Dict[str, str]:
 
 
 class DomainCategoryMatcher:
-  """Matcher to find categories for domains."""
+  """Matcher to find categories for urls."""
 
   def __init__(self) -> None:
     self.categories = _load_categories(DOMAIN_CATEGORIES)
 
-  def match_url(self, url: str) -> Optional[str]:
+  def _match_url(self, url: str) -> Optional[str]:
+    domain = urlparse("http://" + url).netloc
+    return self.categories.get(domain, None)
+
+  def get_category(self, url: str, is_control: bool) -> Optional[str]:
     """Return the category for a url if known.
 
     Args:
       url: string of the form
        "www.google.com", "1.1.1.1", or "test.com/path"
+      is_control: is this url a control url for the test?
 
-    Returns: a string category like "Online Dating" or None
+    Returns: a string category like "Online Dating", "Control" or None
     """
-    domain = urlparse("http://" + url).netloc
-    return self.categories.get(domain, None)
+    if is_control:
+      return "Control"
+    return self._match_url(url)

--- a/pipeline/metadata/flatten_base.py
+++ b/pipeline/metadata/flatten_base.py
@@ -6,7 +6,6 @@ import os
 from typing import Optional, Dict, List, Any, Union
 
 from pipeline.metadata.blockpage import BlockpageMatcher
-from pipeline.metadata.domain_categories import DomainCategoryMatcher
 
 # Custom Type
 # All or part of a scan row to be written to bigquery
@@ -84,13 +83,6 @@ def _reconstruct_http_response(row: Row) -> str:
     full_response += header + '\r\n'
   full_response += '\r\n' + row['received_body']
   return full_response
-
-
-def get_category(category_matcher: DomainCategoryMatcher, domain: str,
-                 is_control: bool) -> Optional[str]:
-  if is_control:
-    return "Control"
-  return category_matcher.match_url(domain)
 
 
 def _add_blockpage_match(blockpage_matcher: BlockpageMatcher, content: str,

--- a/pipeline/metadata/flatten_hyperquack.py
+++ b/pipeline/metadata/flatten_hyperquack.py
@@ -114,33 +114,19 @@ class HyperquackFlattener():
         domain = sent_domain
 
       row = {
-          'domain':
-              domain,
-          'category':
-              flatten_base.get_category(self.category_matcher, domain,
-                                        is_control),
-          'ip':
-              scan['Server'],
-          'date':
-              date,
-          'start_time':
-              result['StartTime'],
-          'end_time':
-              result['EndTime'],
-          'anomaly':
-              scan['Blocked'],
-          'success':
-              result['Success'],
-          'stateful_block':
-              scan['StatefulBlock'],
-          'is_control':
-              is_control,
-          'controls_failed':
-              scan['FailSanity'],
-          'measurement_id':
-              random_measurement_id,
-          'source':
-              flatten_base.source_from_filename(filename),
+          'domain': domain,
+          'category': self.category_matcher.get_category(domain, is_control),
+          'ip': scan['Server'],
+          'date': date,
+          'start_time': result['StartTime'],
+          'end_time': result['EndTime'],
+          'anomaly': scan['Blocked'],
+          'success': result['Success'],
+          'stateful_block': scan['StatefulBlock'],
+          'is_control': is_control,
+          'controls_failed': scan['FailSanity'],
+          'measurement_id': random_measurement_id,
+          'source': flatten_base.source_from_filename(filename),
       }
 
       if 'Received' in result:
@@ -174,33 +160,19 @@ class HyperquackFlattener():
       is_control = 'control_url' in response
 
       row = {
-          'domain':
-              domain,
-          'category':
-              flatten_base.get_category(self.category_matcher, domain,
-                                        is_control),
-          'ip':
-              scan['vp'],
-          'date':
-              date,
-          'start_time':
-              response['start_time'],
-          'end_time':
-              response['end_time'],
-          'anomaly':
-              scan['anomaly'],
-          'success':
-              response['matches_template'],
-          'stateful_block':
-              scan['stateful_block'],
-          'is_control':
-              is_control,
-          'controls_failed':
-              scan.get('controls_failed', None),
-          'measurement_id':
-              random_measurement_id,
-          'source':
-              flatten_base.source_from_filename(filename),
+          'domain': domain,
+          'category': self.category_matcher.get_category(domain, is_control),
+          'ip': scan['vp'],
+          'date': date,
+          'start_time': response['start_time'],
+          'end_time': response['end_time'],
+          'anomaly': scan['anomaly'],
+          'success': response['matches_template'],
+          'stateful_block': scan['stateful_block'],
+          'is_control': is_control,
+          'controls_failed': scan.get('controls_failed', None),
+          'measurement_id': random_measurement_id,
+          'source': flatten_base.source_from_filename(filename),
       }
 
       if 'response' in response:

--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -244,7 +244,7 @@ class SatelliteFlattener():
     row = {
         'domain': scan['query'],
         'is_control': False,  # v1 doesn't have domain controls
-        'category': self.category_matcher.match_url(scan['query']),
+        'category': self.category_matcher.get_category(scan['query'], False),
         'ip': scan.get('resolver', scan.get('ip')),
         'is_control_ip': filename == SATELLITE_ANSWERS_CONTROL_FILE,
         'date': date,
@@ -281,8 +281,8 @@ class SatelliteFlattener():
         'is_control':
             is_control_domain,
         'category':
-            flatten_base.get_category(self.category_matcher, scan['test_url'],
-                                      is_control_domain),
+            self.category_matcher.get_category(scan['test_url'],
+                                               is_control_domain),
         'ip':
             scan['vp'],
         'is_control_ip':
@@ -376,8 +376,8 @@ class SatelliteFlattener():
           'is_control':
               is_control_domain,
           'category':
-              flatten_base.get_category(self.category_matcher, scan['test_url'],
-                                        is_control_domain),
+              self.category_matcher.get_category(scan['test_url'],
+                                                 is_control_domain),
           'ip':
               scan['vp'],
           'is_control_ip':

--- a/pipeline/metadata/test_domain_categories.py
+++ b/pipeline/metadata/test_domain_categories.py
@@ -10,31 +10,37 @@ class BlockpageTest(unittest.TestCase):
 
   def test_no_category(self) -> None:
     matcher = domain_categories.DomainCategoryMatcher()
-    self.assertIsNone(matcher.match_url('site-with-no-category.com'))
+    self.assertIsNone(matcher.get_category('site-with-no-category.com', False))
 
   def test_match_category(self) -> None:
     matcher = domain_categories.DomainCategoryMatcher()
-    self.assertEqual('LGBT', matcher.match_url('amnestyusa.org'))
+    self.assertEqual('LGBT', matcher.get_category('amnestyusa.org', False))
 
   def test_match_subdomain(self) -> None:
     matcher = domain_categories.DomainCategoryMatcher()
-    self.assertEqual('Gaming', matcher.match_url('na.leagueoflegends.com'))
+    self.assertEqual('Gaming',
+                     matcher.get_category('na.leagueoflegends.com', False))
 
   def test_match_non_com_tld(self) -> None:
     matcher = domain_categories.DomainCategoryMatcher()
-    self.assertEqual('Economics', matcher.match_url('dfid.gov.uk'))
+    self.assertEqual('Economics', matcher.get_category('dfid.gov.uk', False))
 
   def test_match_ip(self) -> None:
     matcher = domain_categories.DomainCategoryMatcher()
     self.assertEqual('Hosting and Blogging Platforms',
-                     matcher.match_url('9.9.9.9'))
+                     matcher.get_category('9.9.9.9', False))
 
   def test_match_url(self) -> None:
     matcher = domain_categories.DomainCategoryMatcher()
-    self.assertEqual('LGBT',
-                     matcher.match_url('76crimes.com/anti-lgbt-laws-malaysia/'))
+    self.assertEqual(
+        'LGBT',
+        matcher.get_category('76crimes.com/anti-lgbt-laws-malaysia/', False))
 
   def test_match_ip_url(self) -> None:
     matcher = domain_categories.DomainCategoryMatcher()
     self.assertEqual('Hosting and Blogging Platforms',
-                     matcher.match_url('1.0.0.1/dns/'))
+                     matcher.get_category('1.0.0.1/dns/', False))
+
+  def test_match_control(self) -> None:
+    matcher = domain_categories.DomainCategoryMatcher()
+    self.assertEqual('Control', matcher.get_category('example.com', True))


### PR DESCRIPTION
Small refactoring. This avoids having to pass `DomainCategoryMatcher` objects into functions.