### PR TITLE
fill source field in satellite data

### DIFF
--- a/pipeline/metadata/test_flatten.py
+++ b/pipeline/metadata/test_flatten.py
@@ -26,7 +26,7 @@ class FlattenMeasurementTest(unittest.TestCase):
   def test_flattenmeasurement_hyperquack(self) -> None:
     """Test flattening a hyperquack measurement."""
 
-    filename = 'gs://firehook-scans/echo/CP_Quack-exho-2019-10-16-01-01-17/results.json'
+    filename = 'gs://firehook-scans/echo/CP_Quack-echo-2019-10-16-01-01-17/results.json'
 
     line = """
     {
@@ -57,7 +57,7 @@ class FlattenMeasurementTest(unittest.TestCase):
         'ip': '146.112.62.39',
         'is_control': False,
         'measurement_id': '',
-        'source': 'CP_Quack-exho-2019-10-16-01-01-17',
+        'source': 'CP_Quack-echo-2019-10-16-01-01-17',
         'start_time': '2020-11-14T07:54:49.246304766-05:00',
         'stateful_block': False,
         'success': True
@@ -103,7 +103,8 @@ class FlattenMeasurementTest(unittest.TestCase):
             'matches_control': 'ip http cert asnum asname'
         },
         'rcode': ['0'],
-        'measurement_id': ''
+        'measurement_id': '',
+        'source': 'CP_Satellite-2020-09-02-12-00-01'
     }
 
     flattener = flatten.FlattenMeasurement()

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -75,7 +75,8 @@ class FlattenSatelliteTest(unittest.TestCase):
             'matches_control': 'ip http cert asnum asname'
         },
         'rcode': ['0'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP_Satellite-2020-09-02-12-00-01'
     }, {
         'domain': 'asana.com',
         'is_control': False,
@@ -91,7 +92,8 @@ class FlattenSatelliteTest(unittest.TestCase):
             'matches_control': 'ip http cert asnum asname'
         },
         'rcode': ['0'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP_Satellite-2020-09-02-12-00-01'
     }, {
         'domain': 'asana.com',
         'is_control': False,
@@ -107,7 +109,8 @@ class FlattenSatelliteTest(unittest.TestCase):
             'matches_control': 'ip http cert asnum asname'
         },
         'rcode': ['0'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP_Satellite-2020-09-02-12-00-01'
     }, {
         'domain': 'asana.com',
         'is_control': False,
@@ -123,7 +126,8 @@ class FlattenSatelliteTest(unittest.TestCase):
             'matches_control': 'ip cert asnum asname'
         },
         'rcode': ['0'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP_Satellite-2020-09-02-12-00-01'
     }, {
         'domain': 'www.ecequality.org',
         'is_control': False,
@@ -139,7 +143,8 @@ class FlattenSatelliteTest(unittest.TestCase):
             'matches_control': ''
         },
         'rcode': ['0'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP_Satellite-2020-09-02-12-00-01'
     }, {
         'domain': 'www.sportsinteraction.com',
         'is_control': False,
@@ -152,7 +157,8 @@ class FlattenSatelliteTest(unittest.TestCase):
         'success': False,
         'received': None,
         'rcode': ['-1'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP_Satellite-2020-09-02-12-00-01'
     }, {
         'domain': 'www.usacasino.com',
         'is_control': False,
@@ -167,7 +173,8 @@ class FlattenSatelliteTest(unittest.TestCase):
             'ip': '217.19.248.132'
         },
         'rcode': ['0'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP_Satellite-2020-09-02-12-00-01'
     }]
 
     flattener = get_satellite_flattener()
@@ -321,7 +328,8 @@ class FlattenSatelliteTest(unittest.TestCase):
             'matches_control': ''
         },
         'rcode': ["0", "0", "0"],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP_Satellite-2021-03-01-12-00-01'
     }, {
         'domain': 'abs-cbn.com',
         'is_control': False,
@@ -341,7 +349,8 @@ class FlattenSatelliteTest(unittest.TestCase):
             'matches_control': ''
         },
         'rcode': ["0", "0", "0"],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP_Satellite-2021-03-01-12-00-01'
     }, {
         'domain': 'login.live.com',
         'is_control': False,
@@ -360,6 +369,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         },
         'rcode': ['0', '0', '0'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-03-15-12-00-01',
         'has_type_a': True
     }, {
         'domain': 'login.live.com',
@@ -379,6 +389,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         },
         'rcode': ['0', '0', '0'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-03-15-12-00-01',
         'has_type_a': True
     }, {
         'domain': 'login.live.com',
@@ -398,6 +409,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         },
         'rcode': ['0', '0', '0'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-03-15-12-00-01',
         'has_type_a': True
     }, {
         'domain': '03.ru',
@@ -439,6 +451,7 @@ class FlattenSatelliteTest(unittest.TestCase):
             'exclude_reason': '',
         },
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-09-16-12-00-01',
         'has_type_a': True
     }]
 
@@ -672,6 +685,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         'ip': '216.238.19.1',
         'is_control_ip': False,
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
         'rcode': ['0'],
         'received': [{
             'asname':
@@ -712,6 +726,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         'ip': '5.39.25.152',
         'is_control_ip': False,
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
         'rcode': ['5', '5', '5'],
         'received': None,
         'success': True,
@@ -746,6 +761,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         'ip': '62.80.182.26',
         'is_control_ip': False,
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
         'rcode': ['-1', '-1', '-1', '-1', '-1', '-1'],
         'received': None,
         'start_time': '2021-10-20T14:51:45.952255246-04:00',

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -99,7 +99,8 @@ class SatelliteTest(unittest.TestCase):
               {'ip': '13.249.134.74', 'asname': 'AMAZON-02','asnum': 16509,'cert': None,'http': '2054d0fd3887e0ded023879770d6cde57633b7881f609f1042d90fedf41685fe', 'matches_control': 'ip http asnum asname'},
               {'ip': '13.249.134.89', 'asname': 'AMAZON-02','asnum': 16509,'cert': None,'http': '0509322329cdae79475531a019a3628aa52598caa0135c5534905f0c4b4f1bac', 'matches_control': 'ip http asnum asname'}
           ],
-          'date': '2020-09-02'
+          'date': '2020-09-02',
+          'source': 'CP_Satellite-2020-09-02-12-00-01'
         },
         {
           'ip': '1.1.1.3',
@@ -116,7 +117,8 @@ class SatelliteTest(unittest.TestCase):
           'received': [
               {'ip': '192.124.249.107', 'matches_control': 'ip'}
           ],
-          'date': '2020-09-02'
+          'date': '2020-09-02',
+          'source': 'CP_Satellite-2020-09-02-12-00-01'
         }
     ]
     # yapf: enable
@@ -150,9 +152,9 @@ class SatelliteTest(unittest.TestCase):
       ("CP_Satellite-2021-04-18-12-00-01/resolvers.json", """{"name":"ns1327.ztomy.com.","vp":"12.5.76.236"}"""),
       ("CP_Satellite-2021-04-18-12-00-01/resolvers.json", """{"name": "rec1pubns2.ultradns.net.", "vp": "64.6.65.6"}"""),
     ]
+    # yapf: enable
 
-    expected = [
-      {
+    expected = [{
         'ip': '185.228.169.37',
         'is_control_ip': False,
         'country': 'IE',
@@ -164,15 +166,26 @@ class SatelliteTest(unittest.TestCase):
         'anomaly': False,
         'success': True,
         'controls_failed': False,
-        'received': [
-            {'ip': '198.35.26.96', 'asname': 'WIKIMEDIA','asnum': 14907,'cert': '9eb21a74a3cf1ecaaf6b19253025b4ca38f182e9f1f3e7355ba3c3004d4b7a10','http': '7b4b4d1bfb0a645c990f55557202f88be48e1eee0c10bdcc621c7b682bf7d2ca', 'matches_control': 'cert asnum asname'},
-        ],
+        'received': [{
+            'ip':
+                '198.35.26.96',
+            'asname':
+                'WIKIMEDIA',
+            'asnum':
+                14907,
+            'cert':
+                '9eb21a74a3cf1ecaaf6b19253025b4ca38f182e9f1f3e7355ba3c3004d4b7a10',
+            'http':
+                '7b4b4d1bfb0a645c990f55557202f88be48e1eee0c10bdcc621c7b682bf7d2ca',
+            'matches_control':
+                'cert asnum asname'
+        },],
         'rcode': ['0', '0', '0'],
         'date': '2021-03-01',
         'start_time': '2021-03-01T12:43:25.3438285-05:00',
-        'end_time': '2021-03-01T12:43:25.3696119-05:00'
-      },
-      {
+        'end_time': '2021-03-01T12:43:25.3696119-05:00',
+        'source': 'CP_Satellite-2021-03-01-12-00-01'
+    }, {
         'ip': '156.154.71.37',
         'is_control_ip': False,
         'country': 'US',
@@ -184,15 +197,16 @@ class SatelliteTest(unittest.TestCase):
         'anomaly': True,
         'success': True,
         'controls_failed': False,
-        'received': [
-            {'ip': '15.126.193.233', 'matches_control': ''},
-        ],
+        'received': [{
+            'ip': '15.126.193.233',
+            'matches_control': ''
+        },],
         'rcode': ['0', '0', '0'],
         'date': '2021-03-01',
         'start_time': '2021-03-01T12:43:25.3438285-05:00',
-        'end_time': '2021-03-01T12:43:25.3696119-05:00'
-      },
-      {
+        'end_time': '2021-03-01T12:43:25.3696119-05:00',
+        'source': 'CP_Satellite-2021-03-01-12-00-01'
+    }, {
         'ip': '87.119.233.243',
         'is_control_ip': False,
         'country': 'RU',
@@ -208,9 +222,9 @@ class SatelliteTest(unittest.TestCase):
         'rcode': [],
         'date': '2021-04-18',
         'start_time': '2021-04-18T14:49:01.62448452-04:00',
-        'end_time': '2021-04-18T14:49:03.624563629-04:00'
-      },
-      {
+        'end_time': '2021-04-18T14:49:03.624563629-04:00',
+        'source': 'CP_Satellite-2021-04-18-12-00-01'
+    }, {
         'ip': '12.5.76.236',
         'is_control_ip': False,
         'country': 'US',
@@ -226,9 +240,9 @@ class SatelliteTest(unittest.TestCase):
         'rcode': ['2'],
         'date': '2021-04-18',
         'start_time': '2021-04-18T14:49:07.712972288-04:00',
-        'end_time': '2021-04-18T14:49:07.749265765-04:00'
-      },
-      {
+        'end_time': '2021-04-18T14:49:07.749265765-04:00',
+        'source': 'CP_Satellite-2021-04-18-12-00-01'
+    }, {
         'ip': '64.6.65.6',
         'is_control_ip': True,
         'name': 'rec1pubns2.ultradns.net.',
@@ -240,15 +254,15 @@ class SatelliteTest(unittest.TestCase):
         'success': True,
         'controls_failed': False,
         'has_type_a': True,
-        'received': [
-            {'ip': '178.18.22.152'}
-        ],
+        'received': [{
+            'ip': '178.18.22.152'
+        }],
         'rcode': ['0', '0'],
         'date': '2021-04-18',
         'start_time': '2021-04-18T14:51:57.561175746-04:00',
-        'end_time': '2021-04-18T14:51:57.61294601-04:00'
-      },
-      {
+        'end_time': '2021-04-18T14:51:57.61294601-04:00',
+        'source': 'CP_Satellite-2021-04-18-12-00-01'
+    }, {
         'ip': '64.6.65.6',
         'is_control_ip': True,
         'name': 'rec1pubns2.ultradns.net.',
@@ -260,16 +274,15 @@ class SatelliteTest(unittest.TestCase):
         'success': True,
         'controls_failed': False,
         'has_type_a': True,
-        'received': [
-            {'ip': '204.187.13.189'}
-        ],
+        'received': [{
+            'ip': '204.187.13.189'
+        }],
         'rcode': ['0', '-1', '0'],
         'date': '2021-04-18',
         'start_time': '2021-04-18T14:51:45.836310062-04:00',
-        'end_time': '2021-04-18T14:51:48.162724942-04:00'
-      }
-    ]
-    # yapf: enable
+        'end_time': '2021-04-18T14:51:48.162724942-04:00',
+        'source': 'CP_Satellite-2021-04-18-12-00-01'
+    }]
 
     with TestPipeline() as p:
       lines = p | 'create data' >> beam.Create(data)


### PR DESCRIPTION
This is necessary for appending to work correctly. Currently we exclude existing data when appending by querying which sources already exist in the table. Without this field we will re-add the same rows whenever we append.