### PR TITLE
remove nested structures in satellite schema

### DIFF
--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -139,11 +139,15 @@ def _process_satellite_v2p2(row: Row, scan: Any) -> Iterator[Row]:
   responses = scan.get('response', [])
   row['controls_failed'] = not scan['passed_liveness']
   row['rcode'] = [str(response['rcode']) for response in responses]
-  row['confidence'] = scan.get('confidence')
-  row['verify'] = {
-      'excluded': scan.get('excluded'),
-      'exclude_reason': ' '.join(scan.get('exclude_reason', []))
-  }
+
+  row['average_confidence'] = scan.get('confidence')['average']
+  row['matches_confidence'] = scan.get('confidence')['matches']
+  row['untagged_controls'] = scan.get('confidence')['untagged_controls']
+  row['untagged_response'] = scan.get('confidence')['untagged_response']
+
+  row['excluded'] = scan.get('excluded', False)
+  row['exclude_reason'] = ' '.join(scan.get('exclude_reason', []))
+
   errors = [
       response['error']
       for response in responses

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -428,16 +428,12 @@ class FlattenSatelliteTest(unittest.TestCase):
                 'ip http cert asnum asname'
         }],
         'rcode': ['0'],
-        'confidence': {
-            'average': 100,
-            'matches': [100],
-            'untagged_controls': False,
-            'untagged_response': False
-        },
-        'verify': {
-            'excluded': False,
-            'exclude_reason': '',
-        },
+        'average_confidence': 100,
+        'matches_confidence': [100],
+        'untagged_controls': False,
+        'untagged_response': False,
+        'excluded': False,
+        'exclude_reason': '',
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'has_type_a': True
     }]
@@ -654,12 +650,10 @@ class FlattenSatelliteTest(unittest.TestCase):
     expected = [{
         'anomaly': False,
         'category': 'E-commerce',
-        'confidence': {
-            'average': 100,
-            'matches': [100],
-            'untagged_controls': False,
-            'untagged_response': False
-        },
+        'average_confidence': 100,
+        'matches_confidence': [100],
+        'untagged_controls': False,
+        'untagged_response': False,
         'controls_failed': False,
         'country': 'US',
         'date': '2021-10-20',
@@ -688,19 +682,15 @@ class FlattenSatelliteTest(unittest.TestCase):
                 'ip http cert asnum asname'
         }],
         'success': True,
-        'verify': {
-            'exclude_reason': '',
-            'excluded': False
-        },
+        'exclude_reason': '',
+        'excluded': False
     }, {
         'anomaly': False,
         'category': 'Provocative Attire',
-        'confidence': {
-            'average': 0,
-            'matches': None,
-            'untagged_controls': False,
-            'untagged_response': False
-        },
+        'average_confidence': 0,
+        'matches_confidence': None,
+        'untagged_controls': False,
+        'untagged_response': False,
         'controls_failed': True,
         'country': 'FR',
         'date': '2021-10-20',
@@ -715,19 +705,15 @@ class FlattenSatelliteTest(unittest.TestCase):
         'rcode': ['5', '5', '5'],
         'received': None,
         'success': True,
-        'verify': {
-            'exclude_reason': '',
-            'excluded': False
-        }
+        'exclude_reason': '',
+        'excluded': False
     }, {
         'anomaly': False,
         'category': 'E-commerce',
-        'confidence': {
-            'average': 0,
-            'matches': None,
-            'untagged_controls': False,
-            'untagged_response': False
-        },
+        'average_confidence': 0,
+        'matches_confidence': None,
+        'untagged_controls': False,
+        'untagged_response': False,
         'controls_failed': True,
         'country': 'UA',
         'date': '2021-10-20',
@@ -750,10 +736,8 @@ class FlattenSatelliteTest(unittest.TestCase):
         'received': None,
         'start_time': '2021-10-20T14:51:45.952255246-04:00',
         'success': False,
-        'verify': {
-            'exclude_reason': '',
-            'excluded': False
-        }
+        'exclude_reason': '',
+        'excluded': False
     }]
 
     flattener = get_satellite_flattener()

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -366,29 +366,18 @@ class SatelliteTest(unittest.TestCase):
     ]
 
     expected = [
-      {
-        'average': 0,
-        'matches': [0],
-        'untagged_controls': False,
-        'untagged_response': True
-      },
-      {
-        'average': 100,
-        'matches': [100, 100, 100, 100],
-        'untagged_controls': False,
-        'untagged_response': False
-      },
-      {
-        'average': 62.5,
-        'matches': [0, 50, 100, 100],
-        'untagged_controls': False,
-        'untagged_response': False
-      }
+      (0, [0], False, True),
+      (100, [100, 100, 100, 100], False, False),
+      (62.5, [0, 50, 100, 100], False, False)
     ]
     # yapf: enable
-    result = [
-        satellite._calculate_confidence(scan, 1)['confidence'] for scan in scans
-    ]
+
+    result = []
+    for scan in scans:
+      scan = satellite._calculate_confidence(scan, 1)
+      result.append((scan['average_confidence'], scan['matches_confidence'],
+                     scan['untagged_controls'], scan['untagged_response']))
+
     self.assertListEqual(result, expected)
 
   def test_verify(self) -> None:
@@ -453,8 +442,7 @@ class SatelliteTest(unittest.TestCase):
     result = []
     for scan in scans:
       scan = satellite._verify(scan)
-      result.append(
-          (scan['verify']['excluded'], scan['verify']['exclude_reason']))
+      result.append((scan['excluded'], scan['exclude_reason']))
 
     self.assertListEqual(result, expected)
 


### PR DESCRIPTION
This removes the use of structured bigquery `record` columns in cases where the data can just be unnested.

so the columns

```
confidence {
  - average
  - matches
  - untagged_controls
  - untagged_response
}
verify {
  - excluded
  - exclude_reason
}
```

become just

```
average_confidence
matches_confidence
untagged_controls
untagged_response
excluded
exclude_reason
```

I'm deliberately not changing any of the logic here, just the field names/structure.
