### PR TITLE
Separate out hyperquack specific schema columns

### DIFF
--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -31,7 +31,6 @@ from google.cloud import bigquery as cloud_bigquery  # type: ignore
 from pipeline.metadata.beam_metadata import DateIpKey, IP_METADATA_PCOLLECTION_NAME, ROWS_PCOLLECION_NAME, make_date_ip_key, merge_metadata_with_rows
 from pipeline.metadata.flatten import Row
 from pipeline.metadata import flatten_base
-from pipeline.metadata import flatten_hyperquack
 from pipeline.metadata import flatten_satellite
 from pipeline.metadata import flatten
 from pipeline.metadata import satellite
@@ -104,10 +103,43 @@ def _add_schemas(schema_a: Dict[str, Any],
 
 HYPERQUACK_BIGQUERY_SCHEMA = _add_schemas(
     BASE_BIGQUERY_SCHEMA,
-    flatten_hyperquack.ADDITIONAL_HYPERQUACK_BIGQUERY_SCHEMA)
+    {
+        'blockpage': ('boolean', 'nullable'),
+        'page_signature': ('string', 'nullable'),
+        'stateful_block': ('boolean', 'nullable'),
+
+        # Column filled in all tables
+        'received_status': ('string', 'nullable'),
+        # Columns filled only in HTTP/HTTPS tables
+        'received_body': ('string', 'nullable'),
+        'received_headers': ('string', 'repeated'),
+        # Columns filled only in HTTPS tables
+        'received_tls_version': ('integer', 'nullable'),
+        'received_tls_cipher_suite': ('integer', 'nullable'),
+        'received_tls_cert': ('string', 'nullable'),
+    })
 
 SATELLITE_BIGQUERY_SCHEMA = _add_schemas(
-    BASE_BIGQUERY_SCHEMA, satellite.ADDITIONAL_SATELLITE_BIGQUERY_SCHEMA)
+    BASE_BIGQUERY_SCHEMA, {
+        'name': ('string', 'nullable'),
+        'is_control_ip': ('boolean', 'nullable'),
+        'received': ('record', 'repeated', {
+            'ip': ('string', 'nullable'),
+            'asnum': ('integer', 'nullable'),
+            'asname': ('string', 'nullable'),
+            'http': ('string', 'nullable'),
+            'cert': ('string', 'nullable'),
+            'matches_control': ('string', 'nullable')
+        }),
+        'rcode': ('string', 'repeated'),
+        'average_confidence': ('float', 'nullable'),
+        'matches_confidence': ('float', 'repeated'),
+        'untagged_controls': ('boolean', 'nullable'),
+        'untagged_response': ('boolean', 'nullable'),
+        'excluded': ('boolean', 'nullable'),
+        'exclude_reason': ('string', 'nullable'),
+        'has_type_a': ('boolean', 'nullable')
+    })
 
 
 def _get_bigquery_schema(scan_type: str) -> Dict[str, Any]:

--- a/pipeline/metadata/flatten_hyperquack.py
+++ b/pipeline/metadata/flatten_hyperquack.py
@@ -14,6 +14,22 @@ from pipeline.metadata.domain_categories import DomainCategoryMatcher
 # echo/discard domain and url content
 SENT_PATTERN = "GET (.*) HTTP/1.1\r\nHost: (.*)\r\n"
 
+HYPERQUACK_BIGQUERY_SCHEMA = {
+    'blockpage': ('boolean', 'nullable'),
+    'page_signature': ('string', 'nullable'),
+    'stateful_block': ('boolean', 'nullable'),
+
+    # Column filled in all tables
+    'received_status': ('string', 'nullable'),
+    # Columns filled only in HTTP/HTTPS tables
+    'received_body': ('string', 'nullable'),
+    'received_headers': ('string', 'repeated'),
+    # Columns filled only in HTTPS tables
+    'received_tls_version': ('integer', 'nullable'),
+    'received_tls_cipher_suite': ('integer', 'nullable'),
+    'received_tls_cert': ('string', 'nullable'),
+}
+
 
 def _extract_domain_from_sent_field(sent: str) -> Optional[str]:
   """Get the url out of a 'sent' field in a measurement.

--- a/pipeline/metadata/flatten_hyperquack.py
+++ b/pipeline/metadata/flatten_hyperquack.py
@@ -14,24 +14,6 @@ from pipeline.metadata.domain_categories import DomainCategoryMatcher
 # echo/discard domain and url content
 SENT_PATTERN = "GET (.*) HTTP/1.1\r\nHost: (.*)\r\n"
 
-# Additional bigquery fields for the satellite data
-# These are in addition to the fields in beam_tables.BASE_BIGQUERY_SCHEMA
-ADDITIONAL_HYPERQUACK_BIGQUERY_SCHEMA = {
-    'blockpage': ('boolean', 'nullable'),
-    'page_signature': ('string', 'nullable'),
-    'stateful_block': ('boolean', 'nullable'),
-
-    # Column filled in all tables
-    'received_status': ('string', 'nullable'),
-    # Columns filled only in HTTP/HTTPS tables
-    'received_body': ('string', 'nullable'),
-    'received_headers': ('string', 'repeated'),
-    # Columns filled only in HTTPS tables
-    'received_tls_version': ('integer', 'nullable'),
-    'received_tls_cipher_suite': ('integer', 'nullable'),
-    'received_tls_cert': ('string', 'nullable'),
-}
-
 
 def _extract_domain_from_sent_field(sent: str) -> Optional[str]:
   """Get the url out of a 'sent' field in a measurement.

--- a/pipeline/metadata/flatten_hyperquack.py
+++ b/pipeline/metadata/flatten_hyperquack.py
@@ -14,7 +14,9 @@ from pipeline.metadata.domain_categories import DomainCategoryMatcher
 # echo/discard domain and url content
 SENT_PATTERN = "GET (.*) HTTP/1.1\r\nHost: (.*)\r\n"
 
-HYPERQUACK_BIGQUERY_SCHEMA = {
+# Additional bigquery fields for the satellite data
+# These are in addition to the fields in beam_tables.BASE_BIGQUERY_SCHEMA
+ADDITIONAL_HYPERQUACK_BIGQUERY_SCHEMA = {
     'blockpage': ('boolean', 'nullable'),
     'page_signature': ('string', 'nullable'),
     'stateful_block': ('boolean', 'nullable'),

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -18,8 +18,8 @@ from pipeline.metadata import flatten_satellite
 from pipeline.metadata import flatten
 
 # Additional bigquery fields for the satellite data
-# These are in addition to the fields in beam_tables.SCAN_BIGQUERY_SCHEMA
-SATELLITE_BIGQUERY_SCHEMA = {
+# These are in addition to the fields in beam_tables.BASE_BIGQUERY_SCHEMA
+ADDITIONAL_SATELLITE_BIGQUERY_SCHEMA = {
     'name': ('string', 'nullable'),
     'is_control_ip': ('boolean', 'nullable'),
     'received': ('record', 'repeated', {

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -17,29 +17,6 @@ from pipeline.metadata.lookup_country_code import country_name_to_code
 from pipeline.metadata import flatten_satellite
 from pipeline.metadata import flatten
 
-# Additional bigquery fields for the satellite data
-# These are in addition to the fields in beam_tables.BASE_BIGQUERY_SCHEMA
-ADDITIONAL_SATELLITE_BIGQUERY_SCHEMA = {
-    'name': ('string', 'nullable'),
-    'is_control_ip': ('boolean', 'nullable'),
-    'received': ('record', 'repeated', {
-        'ip': ('string', 'nullable'),
-        'asnum': ('integer', 'nullable'),
-        'asname': ('string', 'nullable'),
-        'http': ('string', 'nullable'),
-        'cert': ('string', 'nullable'),
-        'matches_control': ('string', 'nullable')
-    }),
-    'rcode': ('string', 'repeated'),
-    'average_confidence': ('float', 'nullable'),
-    'matches_confidence': ('float', 'repeated'),
-    'untagged_controls': ('boolean', 'nullable'),
-    'untagged_response': ('boolean', 'nullable'),
-    'excluded': ('boolean', 'nullable'),
-    'exclude_reason': ('string', 'nullable'),
-    'has_type_a': ('boolean', 'nullable')
-}
-
 BLOCKPAGE_BIGQUERY_SCHEMA = {
     # Columns from Censored Planet data
     'domain': ('string', 'nullable'),

--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -24,7 +24,6 @@ import apache_beam.testing.util as beam_test_util
 
 from pipeline import beam_tables
 from pipeline.metadata.ip_metadata_chooser import FakeIpMetadataChooserFactory
-from pipeline.metadata import flatten_hyperquack
 from pipeline.metadata import satellite
 
 
@@ -39,17 +38,15 @@ class PipelineMainTest(unittest.TestCase):
   def test_get_bigquery_schema_hyperquack(self) -> None:
     """Test getting the right bigquery schema for data types."""
     echo_schema = beam_tables._get_bigquery_schema('echo')
-    all_hyperquack_top_level_columns = (
-        list(beam_tables.BASE_BIGQUERY_SCHEMA.keys()) +
-        list(flatten_hyperquack.ADDITIONAL_HYPERQUACK_BIGQUERY_SCHEMA.keys()))
+    all_hyperquack_top_level_columns = list(
+        beam_tables.HYPERQUACK_BIGQUERY_SCHEMA.keys())
     self.assertListEqual(
         list(echo_schema.keys()), all_hyperquack_top_level_columns)
 
   def test_get_bigquery_schema_satellite(self) -> None:
     satellite_schema = beam_tables._get_bigquery_schema('satellite')
-    all_satellite_top_level_columns = (
-        list(beam_tables.BASE_BIGQUERY_SCHEMA.keys()) +
-        list(satellite.ADDITIONAL_SATELLITE_BIGQUERY_SCHEMA.keys()))
+    all_satellite_top_level_columns = list(
+        beam_tables.SATELLITE_BIGQUERY_SCHEMA.keys())
     self.assertListEqual(
         list(satellite_schema.keys()), all_satellite_top_level_columns)
 

--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -25,6 +25,7 @@ import apache_beam.testing.util as beam_test_util
 from pipeline import beam_tables
 from pipeline.metadata.ip_metadata_chooser import FakeIpMetadataChooserFactory
 from pipeline.metadata import satellite
+from pipeline.metadata import flatten_hyperquack
 
 
 class PipelineMainTest(unittest.TestCase):
@@ -32,18 +33,24 @@ class PipelineMainTest(unittest.TestCase):
 
   # pylint: disable=protected-access
 
-  def test_get_bigquery_schema(self) -> None:
+  def test_get_bigquery_schema_hyperquack(self) -> None:
     """Test getting the right bigquery schema for data types."""
     echo_schema = beam_tables._get_bigquery_schema('echo')
-    self.assertEqual(echo_schema, beam_tables.SCAN_BIGQUERY_SCHEMA)
+    all_hyperquack_top_level_columns = (
+        list(beam_tables.BASE_BIGQUERY_SCHEMA.keys()) +
+        list(flatten_hyperquack.HYPERQUACK_BIGQUERY_SCHEMA.keys()))
+    self.assertListEqual(
+        list(echo_schema.keys()), all_hyperquack_top_level_columns)
 
+  def test_get_bigquery_schema_satellite(self) -> None:
     satellite_schema = beam_tables._get_bigquery_schema('satellite')
     all_satellite_top_level_columns = (
-        list(beam_tables.SCAN_BIGQUERY_SCHEMA.keys()) +
+        list(beam_tables.BASE_BIGQUERY_SCHEMA.keys()) +
         list(satellite.SATELLITE_BIGQUERY_SCHEMA.keys()))
     self.assertListEqual(
         list(satellite_schema.keys()), all_satellite_top_level_columns)
 
+  def test_get_bigquery_schema_blockpage(self) -> None:
     blockpage_schema = beam_tables._get_bigquery_schema('blockpage')
     self.assertEqual(blockpage_schema, satellite.BLOCKPAGE_BIGQUERY_SCHEMA)
 

--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -24,12 +24,15 @@ import apache_beam.testing.util as beam_test_util
 
 from pipeline import beam_tables
 from pipeline.metadata.ip_metadata_chooser import FakeIpMetadataChooserFactory
-from pipeline.metadata import satellite
 from pipeline.metadata import flatten_hyperquack
+from pipeline.metadata import satellite
 
 
 class PipelineMainTest(unittest.TestCase):
   """Unit tests for beam pipeline steps."""
+
+  def setUp(self) -> None:
+    self.maxDiff = None  # pylint: disable=invalid-name
 
   # pylint: disable=protected-access
 
@@ -38,7 +41,7 @@ class PipelineMainTest(unittest.TestCase):
     echo_schema = beam_tables._get_bigquery_schema('echo')
     all_hyperquack_top_level_columns = (
         list(beam_tables.BASE_BIGQUERY_SCHEMA.keys()) +
-        list(flatten_hyperquack.HYPERQUACK_BIGQUERY_SCHEMA.keys()))
+        list(flatten_hyperquack.ADDITIONAL_HYPERQUACK_BIGQUERY_SCHEMA.keys()))
     self.assertListEqual(
         list(echo_schema.keys()), all_hyperquack_top_level_columns)
 
@@ -46,7 +49,7 @@ class PipelineMainTest(unittest.TestCase):
     satellite_schema = beam_tables._get_bigquery_schema('satellite')
     all_satellite_top_level_columns = (
         list(beam_tables.BASE_BIGQUERY_SCHEMA.keys()) +
-        list(satellite.SATELLITE_BIGQUERY_SCHEMA.keys()))
+        list(satellite.ADDITIONAL_SATELLITE_BIGQUERY_SCHEMA.keys()))
     self.assertListEqual(
         list(satellite_schema.keys()), all_satellite_top_level_columns)
 


### PR DESCRIPTION
This separates out all the columns that are never filled in the satellite tables. (All yellow columns [here](https://docs.google.com/document/d/1BMohMUiqJzYnTR8fdEqb1Ang5r1oW_aEHdsxQraQPR8/edit?hl=en#)) 
Now they will only exist in the hyperquack data.

columns are:
- blockpage
- page_signature
- stateful_block
- received_status
- received_body
- received_headers
- received_tls_version
- received_tls_cipher_suite
- received_tls_cert