### PR TITLE
remove global INTERFERENCE_IPDOMAIN which cannot work

### DIFF
--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -2,11 +2,10 @@
 
 from __future__ import absolute_import
 
-from collections import defaultdict
 import json
 import pathlib
 import re
-from typing import Optional, Dict, Any, Iterator, Set
+from typing import Optional, Dict, Any, Iterator
 import datetime
 
 from pipeline.metadata import flatten_base
@@ -15,7 +14,6 @@ from pipeline.metadata.blockpage import BlockpageMatcher
 from pipeline.metadata.domain_categories import DomainCategoryMatcher
 
 SATELLITE_TAGS = {'ip', 'http', 'asnum', 'asname', 'cert'}
-INTERFERENCE_IPDOMAIN: Dict[str, Set[str]] = defaultdict(set)
 SATELLITE_V2_1_START_DATE = datetime.date(2021, 3, 1)
 SATELLITE_V2_2_START_DATE = datetime.date(2021, 6, 24)
 
@@ -101,9 +99,6 @@ def _process_received_ips(
 
   for ip in received_ips:
     row['received'] = {'ip': ip}
-    if row['anomaly']:
-      # Track domains per IP for interference
-      INTERFERENCE_IPDOMAIN[ip].add(row['domain'])
     if isinstance(received_ips, dict):
       row['received']['matches_control'] = ' '.join(  # pylint: disable=unsupported-assignment-operation
           [tag for tag in received_ips[ip] if tag in SATELLITE_TAGS])

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -45,7 +45,6 @@ SCAN_TYPE_SATELLITE = 'satellite'
 SCAN_TYPE_BLOCKPAGE = 'blockpage'
 
 CDN_REGEX = re.compile("AMAZON|Akamai|OPENDNS|CLOUDFLARENET|GOOGLE")
-VERIFY_THRESHOLD = 2  # 2 or 3 works best to optimize the FP:TP ratio.
 NUM_DOMAIN_PARTITIONS = 250
 NUM_SATELLITE_INPUT_PARTITIONS = 3
 
@@ -581,12 +580,6 @@ def _verify(scan: Dict[str, Any]) -> Dict[str, Any]:
         # CDN IPs
         scan['excluded'] = True
         reasons.append('is_CDN')
-      unique_domains = flatten_satellite.INTERFERENCE_IPDOMAIN.get(
-          received['ip'])
-      if unique_domains and len(unique_domains) <= VERIFY_THRESHOLD:
-        # IPs that appear <= threshold times across all interference
-        scan['excluded'] = True
-        reasons.append('domain_below_threshold')
     scan['exclude_reason'] = ' '.join(reasons)
   return scan
 

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -10,7 +10,6 @@ import apache_beam.testing.util as beam_test_util
 
 from pipeline.metadata.flatten_base import Row
 from pipeline.metadata import satellite
-from pipeline.metadata import flatten_satellite
 from pipeline.metadata import flatten
 
 
@@ -410,18 +409,6 @@ class SatelliteTest(unittest.TestCase):
         'date': '2020-09-02'
       },
       {
-        'ip': '114.114.114.110',
-        'country': 'CN',
-        'name': 'name',
-        'domain': 'ar.m.wikipedia.org',
-        'category': 'E-commerce',
-        'error': None,
-        'anomaly': True,
-        'success': True,
-        'received': [{'ip': '198.35.26.96', 'matches_control': ''}],
-        'date': '2020-09-02'
-      },
-      {
         'ip': '1.1.1.3',
         'country': 'US',
         'name': 'special',
@@ -439,16 +426,9 @@ class SatelliteTest(unittest.TestCase):
     ]
     # yapf: enable
 
-    # mock data for the global interference IP - DOMAIN mapping
-    flatten_satellite.INTERFERENCE_IPDOMAIN = {
-        '104.20.161.134': {'abs-cbn.com', 'xyz.com', 'blah.com'},
-        '198.35.26.96': {'ar.m.wikipedia.org'},
-    }
     expected = [
         # answer IP is returned for multiple domains: likely to be interference
         (False, ''),
-        # answer IP is returned for one domain: false positive
-        (True, 'domain_below_threshold'),
         # answer IPs are CDN: false positive
         (True, 'is_CDN is_CDN'),
     ]


### PR DESCRIPTION
The current code is using the global `INTERFERENCE_IPDOMAIN` to pass information between computation in `flatten_satellite.py` and `satellite.py`. Although this can be mocked out to work in unit tests it cannot possibly work when running a distributed pipeline since different workers won't have the same `INTERFERENCE_IPDOMAIN`.

Querying the actual data 'domain_below_threshold' never shows up in exclude_reason. So this is definitely not working.

To add this functionality back we'll have to figure out a way to calculate it (probably via a group) and pass the value in the pipeline.

(Take two of https://github.com/censoredplanet/censoredplanet-analysis/pull/110)