### PR TITLE
update query to accommodate multiple errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ disable=abstract-method, # raises false positives in beam
 
 [FORMAT]
 # Allow some single and two letter variables, but keep overall invalid-name rule
-good-names=i,j,k,f,ex,e,_,p,ip,cm
+# Also allow censoredplanet-analysis as a module name
+good-names=i,j,k,f,ex,e,_,p,ip,cm,censoredplanet-analysis
 # Don't require docstring for short code segments
 docstring-min-length=10


### PR DESCRIPTION
Parse multiple mismatch error strings in the error data.

Fortunately the errors are already ordered by importance (with certs errors first, body errors last) so we can just take the first one.

This introduces the new outcome `content/header_mismatch`.

In the future we may want to change the format in the base table to accommodate the multiple errors in a structured way, but for now this should fix the dashboard.

TESTED: ran on the prod data and saw no unknowns.