### PR TITLE
flatten measurements for satellite

### DIFF
--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -401,13 +401,15 @@ class PipelineManualE2eTest(unittest.TestCase):
 
       written_rows = get_bq_rows(client,
                                  [get_bq_base_table_name(SATELLITE_SCAN_TYPE)])
-      self.assertEqual(len(written_rows), 8)
+      self.assertEqual(len(written_rows), 16)
 
-      all_expected_domains = [
-          'www.americorps.gov', 'www.americorps.gov', 'custhelp.com',
-          'custhelp.com', 'www.mainichi.co.jp', 'www.mainichi.co.jp',
-          'www.unwatch.org', 'www.unwatch.org'
+      expected_double_domains = ['custhelp.com', 'www.unwatch.org']
+      expected_quad_domains = [
+          'a.root-servers.net', 'www.americorps.gov', 'www.mainichi.co.jp'
       ]
+
+      all_expected_domains = (
+          expected_double_domains * 2 + expected_quad_domains * 4)
 
       written_domains = [row[0] for row in written_rows]
       self.assertListEqual(
@@ -427,13 +429,16 @@ class PipelineManualE2eTest(unittest.TestCase):
 
       written_rows = get_bq_rows(client,
                                  [get_bq_base_table_name(SATELLITE_SCAN_TYPE)])
-      self.assertEqual(len(written_rows), 10)
+      self.assertEqual(len(written_rows), 18)
 
-      all_expected_domains = [
-          '11st.co.kr', '1688.com', '11st.co.kr', '11st.co.kr', '1922.gov.tw',
-          '1922.gov.tw', 'ajax.aspnetcdn.com', 'alipay.com', '1337x.to',
-          '104.com.tw'
-      ]
+      expected_single_domains = ['1688.com', '1337x.to', '104.com.tw']
+      expected_double_domains = ['a.root-servers.net', '1922.gov.tw']
+      expected_triple_domains = ['11st.co.kr']
+      expected_quad_domains = ['ajax.aspnetcdn.com', 'alipay.com']
+
+      all_expected_domains = (
+          expected_single_domains + expected_double_domains * 2 +
+          expected_triple_domains * 3 + expected_quad_domains * 4)
 
       written_domains = [row[0] for row in written_rows]
 

--- a/pipeline/metadata/beam_metadata.py
+++ b/pipeline/metadata/beam_metadata.py
@@ -53,10 +53,12 @@ def merge_metadata_with_rows(  # pylint: disable=unused-argument
     new_row.update(row)
     if field == 'received':
       if new_row['received']:
-        new_row['received'].update(ip_metadata)
-        new_row['received'].pop('date', None)
-        new_row['received'].pop('name', None)
-        new_row['received'].pop('country', None)
+        # Double-flattened rows are stored with a single received ip in each list
+        # to be reconstructed later
+        new_row['received'][0].update(ip_metadata)
+        new_row['received'][0].pop('date', None)
+        new_row['received'][0].pop('name', None)
+        new_row['received'][0].pop('country', None)
     else:
       new_row.update(ip_metadata)
     yield new_row

--- a/pipeline/metadata/flatten_base.py
+++ b/pipeline/metadata/flatten_base.py
@@ -18,7 +18,7 @@ Row = Dict[str, Any]
 CONTROL_URLS = [
     'example5718349450314.com',  # echo/discard
     'rtyutgyhefdafioasfjhjhi.com',  # HTTP/S
-    'a.root-servers.net'  # Satellite
+    'a.root-servers.net',  # Satellite
     'www.example.com'  # Satellite
 ]
 

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -241,7 +241,7 @@ def unflatten_received_ip_rows(
     rows: roundtrip rows with a single received ip
 
   Returns:
-    roundtrip rows aggregated so they have an array of recieved responses
+    roundtrip rows aggregated so they have an array of received responses
   """
   # PCollection[Tuple[str,Row]]
   keyed_by_roundtrip_id = (

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -238,7 +238,7 @@ def unflatten_received_ip_rows(
   """Unflatten so that each row contains a array of answer IPs
 
   Args:
-    rows: roundtrip rows with a single recieved ip
+    rows: roundtrip rows with a single received ip
 
   Returns:
     roundtrip rows aggregated so they have an array of recieved responses

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -405,14 +405,18 @@ def _unflatten_satellite(flattened_measurement: Iterable[Row]) -> Iterator[Row]:
     yield combined
 
 
-def flatten_received_ips(row: Row) -> Iterator[Row]:
+def flatten_received_ips(dns_roundtrip: Row) -> Iterator[Row]:
   """Flatten a row with multiple received ips into rows with a single ip.
 
   Args:
     row element like
       {
         "field": "value"
-        "received" [<dict1>, <dict2>]
+        "received" [{
+            'ip': '1.2.3.4'
+        },{
+            'ip': '5.6.7.8'
+        }]
       }
 
   Returns:
@@ -420,26 +424,30 @@ def flatten_received_ips(row: Row) -> Iterator[Row]:
       {
         "field": "value"
         "roundtrip_id" = "a"
-        "received" [<dict1>]
+        "received" [{
+            'ip': '1.2.3.4'
+        }]
       }
       {
         "field": "value"
         "roundtrip_id" = "a"
-        "received" [<dict2>]
+        "received" [{
+            'ip': '5.6.7.8'
+        }]
       }
   """
   # This id is used to reconstruct the row structure when unflattening
-  row['roundtrip_id'] = uuid.uuid4().hex
+  dns_roundtrip['roundtrip_id'] = uuid.uuid4().hex
 
-  all_received = row['received']
+  all_received = dns_roundtrip['received']
 
   if len(all_received) == 0:
-    yield row
+    yield dns_roundtrip
     return
 
   for received in all_received:
-    row['received'] = [received]
-    yield row.copy()
+    dns_roundtrip['received'] = [received]
+    yield dns_roundtrip.copy()
 
 
 def process_satellite_with_tags(

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -8,6 +8,7 @@ import logging
 import pathlib
 import re
 from typing import Tuple, Dict, Any, Iterator, Iterable
+import uuid
 
 import apache_beam as beam
 
@@ -72,8 +73,8 @@ def _get_satellite_date_partition(row: Row, _: int) -> int:
 
 def _make_date_received_ip_key(row: Row) -> DateIpKey:
   """Makes a tuple key of the date and received ip from a given row dict."""
-  if row['received']:
-    return (row['date'], row['received']['ip'])
+  if row['received'] is not None and len(row['received']) > 0:
+    return (row['date'], row['received'][0]['ip'])
   return (row['date'], '')
 
 
@@ -232,29 +233,29 @@ def add_received_ip_tags(
   return rows_with_tags
 
 
-def unflatten_rows(
+def unflatten_received_ip_rows(
     rows: beam.pvalue.PCollection[Row]) -> beam.pvalue.PCollection[Row]:
   """Unflatten so that each row contains a array of answer IPs
 
   Args:
-    rows: measurement rows with a single recieved ip
+    rows: roundtrip rows with a single recieved ip
 
   Returns:
-    measurement rows aggregated so they have an array of recieved responses
+    roundtrip rows aggregated so they have an array of recieved responses
   """
   # PCollection[Tuple[str,Row]]
-  keyed_by_measurement_id = (
-      rows | 'key by measurement id' >>
+  keyed_by_roundtrip_id = (
+      rows | 'key by roundtrip id' >>
       beam.Map(lambda row:
-               (row['measurement_id'], row)).with_output_types(Tuple[str, Row]))
+               (row['roundtrip_id'], row)).with_output_types(Tuple[str, Row]))
 
   # PCollection[Tuple[str,Iterable[Row]]]
-  grouped_by_measurement_id = (
-      keyed_by_measurement_id | 'group by measurement id' >> beam.GroupByKey())
+  grouped_by_roundtrip_id = (
+      keyed_by_roundtrip_id | 'group by roundtrip id' >> beam.GroupByKey())
 
   # PCollection[Row]
   unflattened_rows = (
-      grouped_by_measurement_id | 'unflatten rows' >> beam.FlatMapTuple(
+      grouped_by_roundtrip_id | 'unflatten rows' >> beam.FlatMapTuple(
           lambda k, v: _unflatten_satellite(v)).with_output_types(Row))
 
   return unflattened_rows
@@ -299,7 +300,7 @@ def _add_satellite_tags(
                     'combine date partitions' >> beam.Flatten())
 
   # PCollection[Row]
-  return unflatten_rows(rows_with_tags)
+  return unflatten_received_ip_rows(rows_with_tags)
 
 
 def post_processing_satellite(
@@ -374,17 +375,16 @@ def _unflatten_satellite(flattened_measurement: Iterable[Row]) -> Iterator[Row]:
     flattened_measurment: list of dicts representing a flattened measurement,
     where each contains an unique answer IP and tags in the 'received' field
     (other fields are the same for each dict).
-    [{'ip':'1.1.1.1','domain':'x.com','measurement_id':'HASH','received':{'ip':'0.0.0.0','tag':'value1'},...},
-     {'ip':'1.1.1.1','domain':'x.com','measurement_id':'HASH','received':{'ip':'0.0.0.1','tag':'value2'},...}]
-    For Satellite v2.2, the 'received' field will already contain an array, e.g.
-    [{'ip':'1.1.1.1','domain':'x.com','measurement_id':'HASH',
-      'received':[{'ip':'0.0.0.0','tag':'value1'},{'ip':'0.0.0.1','tag':'value2'}],...}]
+    [{'ip':'1.1.1.1','domain':'x.com','measurement_id':'HASH','received':[{'ip':'0.0.0.1','tag':'value1'},...}],
+     {'ip':'1.1.1.1','domain':'x.com','measurement_id':'HASH','received':[{'ip':'0.0.0.2','tag':'value2'},...}],
+
 
   Yields:
-    Row with common fields remaining the same, 'measurement_id' removed,
+    Row with common fields remaining the same,
     and 'received' mapped to an array of answer IP dictionaries.
-    {'ip':'1.1.1.1','domain':'x.com','received':[{'ip':'0.0.0.0','tag':'value1'},{'ip':'0.0.0.1','tag':'value2'}],...}
+    {'ip':'1.1.1.1','domain':'x.com','received':[{'ip':'0.0.0.1','tag':'value1'},{'ip':'0.0.0.2','tag':'value2'}],...}
   """
+
   if flattened_measurement:
     # Get common fields and update 'received' with array of all answer IPs
     combined: Row = {'received': []}
@@ -396,12 +396,50 @@ def _unflatten_satellite(flattened_measurement: Iterable[Row]) -> Iterator[Row]:
         combined['received'] += received
       elif received:
         combined['received'].append(received)
-    combined.pop('measurement_id')
     # Remove extra tag fields from the measurement. These may be added
     # during the tagging step if a vantage point also appears as a response IP.
     for tag in ['asname', 'asnum', 'http', 'cert']:
       combined.pop(tag, None)
+
+    combined.pop('roundtrip_id')  # Remove roundtrip id
     yield combined
+
+
+def flatten_received_ips(row: Row) -> Iterator[Row]:
+  """Flatten a row with multiple received ips into rows with a single ip.
+
+  Args:
+    row element like
+      {
+        "field": "value"
+        "received" [<dict1>, <dict2>]
+      }
+
+  Returns:
+    Rows like
+      {
+        "field": "value"
+        "roundtrip_id" = "a"
+        "received" [<dict1>]
+      }
+      {
+        "field": "value"
+        "roundtrip_id" = "a"
+        "received" [<dict2>]
+      }
+  """
+  # This id is used to reconstruct the row structure when unflattening
+  row['roundtrip_id'] = uuid.uuid4().hex
+
+  all_received = row['received']
+
+  if len(all_received) == 0:
+    yield row
+    return
+
+  for received in all_received:
+    row['received'] = [received]
+    yield row.copy()
 
 
 def process_satellite_with_tags(
@@ -421,13 +459,19 @@ def process_satellite_with_tags(
   rows = (
       row_lines | 'flatten json' >> beam.ParDo(
           flatten.FlattenMeasurement()).with_output_types(Row))
+
+  # PCollection[Row] each with only a single element in the received arrays
+  received_ip_flattened_rows = (
+      rows | 'flatten received ips' >>
+      beam.FlatMap(flatten_received_ips).with_output_types(Row))
+
   # PCollection[Row]
   tag_rows = (
       tag_lines | 'tag rows' >>
       beam.FlatMapTuple(_read_satellite_tags).with_output_types(Row))
 
   # PCollection[Row]
-  rows_with_metadata = _add_satellite_tags(rows, tag_rows)
+  rows_with_metadata = _add_satellite_tags(received_ip_flattened_rows, tag_rows)
 
   return rows_with_metadata
 
@@ -523,7 +567,7 @@ def _calculate_confidence(scan: Dict[str, Any],
 
   for answer in scan['received'] or []:
     # check tags for each answer IP
-    matches_control = answer['matches_control'].split()
+    matches_control = answer.get('matches_control', '').split()
     total_tags = 0
     matching_tags = 0
 

--- a/pipeline/metadata/test_flatten.py
+++ b/pipeline/metadata/test_flatten.py
@@ -98,10 +98,10 @@ class FlattenMeasurementTest(unittest.TestCase):
         'error': None,
         'anomaly': False,
         'success': True,
-        'received': {
+        'received': [{
             'ip': '151.101.1.184',
             'matches_control': 'ip http cert asnum asname'
-        },
+        }],
         'rcode': ['0'],
         'measurement_id': '',
         'source': 'CP_Satellite-2020-09-02-12-00-01'

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -9,6 +9,8 @@ from pipeline.metadata.domain_categories import DomainCategoryMatcher
 
 from pipeline.metadata import flatten_satellite
 
+# pylint: disable=too-many-lines
+
 
 def get_satellite_flattener() -> flatten_satellite.SatelliteFlattener:
   blockpage_matcher = BlockpageMatcher()
@@ -70,61 +72,19 @@ class FlattenSatelliteTest(unittest.TestCase):
         'error': None,
         'anomaly': False,
         'success': True,
-        'received': {
+        'received': [{
             'ip': '151.101.1.184',
             'matches_control': 'ip http cert asnum asname'
-        },
-        'rcode': ['0'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
-        'source': 'CP_Satellite-2020-09-02-12-00-01'
-    }, {
-        'domain': 'asana.com',
-        'is_control': False,
-        'category': 'E-commerce',
-        'ip': '67.69.184.215',
-        'is_control_ip': False,
-        'date': '2020-09-02',
-        'error': None,
-        'anomaly': False,
-        'success': True,
-        'received': {
+        }, {
             'ip': '151.101.129.184',
             'matches_control': 'ip http cert asnum asname'
-        },
-        'rcode': ['0'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
-        'source': 'CP_Satellite-2020-09-02-12-00-01'
-    }, {
-        'domain': 'asana.com',
-        'is_control': False,
-        'category': 'E-commerce',
-        'ip': '67.69.184.215',
-        'is_control_ip': False,
-        'date': '2020-09-02',
-        'error': None,
-        'anomaly': False,
-        'success': True,
-        'received': {
+        }, {
             'ip': '151.101.193.184',
             'matches_control': 'ip http cert asnum asname'
-        },
-        'rcode': ['0'],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
-        'source': 'CP_Satellite-2020-09-02-12-00-01'
-    }, {
-        'domain': 'asana.com',
-        'is_control': False,
-        'category': 'E-commerce',
-        'ip': '67.69.184.215',
-        'is_control_ip': False,
-        'date': '2020-09-02',
-        'error': None,
-        'anomaly': False,
-        'success': True,
-        'received': {
+        }, {
             'ip': '151.101.65.184',
             'matches_control': 'ip cert asnum asname'
-        },
+        }],
         'rcode': ['0'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP_Satellite-2020-09-02-12-00-01'
@@ -138,10 +98,9 @@ class FlattenSatelliteTest(unittest.TestCase):
         'error': None,
         'anomaly': True,
         'success': True,
-        'received': {
-            'ip': '160.153.136.3',
-            'matches_control': ''
-        },
+        'received': [{
+            'ip': '160.153.136.3'
+        }],
         'rcode': ['0'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP_Satellite-2020-09-02-12-00-01'
@@ -155,7 +114,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         'error': 'no_answer',
         'anomaly': None,
         'success': False,
-        'received': None,
+        'received': [],
         'rcode': ['-1'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP_Satellite-2020-09-02-12-00-01'
@@ -169,9 +128,9 @@ class FlattenSatelliteTest(unittest.TestCase):
         'error': None,
         'anomaly': None,
         'success': True,
-        'received': {
+        'received': [{
             'ip': '217.19.248.132'
-        },
+        }],
         'rcode': ['0'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP_Satellite-2020-09-02-12-00-01'
@@ -205,7 +164,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         "response": {
             "104.20.161.135": [],
             "104.20.161.134": [],
-            "rcode": ["0", "0", "0"]
+            "rcode": ["0"]
         },
         "passed_control": True,
         "connect_error": False,
@@ -323,51 +282,31 @@ class FlattenSatelliteTest(unittest.TestCase):
         'anomaly': True,
         'success': True,
         'controls_failed': False,
-        'received': {
-            'ip': '104.20.161.135',
-            'matches_control': ''
-        },
-        'rcode': ["0", "0", "0"],
+        'received': [{
+            'ip': '104.20.161.135'
+        }, {
+            'ip': '104.20.161.134'
+        }],
+        'rcode': ["0"],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP_Satellite-2021-03-01-12-00-01'
     }, {
-        'domain': 'abs-cbn.com',
-        'is_control': False,
-        'category': 'Culture',
-        'ip': '114.114.114.110',
-        'is_control_ip': False,
-        'country': 'CN',
-        'date': '2021-03-05',
-        'start_time': '2021-03-05T15:32:05.324807502-05:00',
-        'end_time': '2021-03-05T15:32:05.366104911-05:00',
-        'error': None,
-        'anomaly': True,
-        'success': True,
-        'controls_failed': False,
-        'received': {
-            'ip': '104.20.161.134',
-            'matches_control': ''
-        },
-        'rcode': ["0", "0", "0"],
-        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
-        'source': 'CP_Satellite-2021-03-01-12-00-01'
-    }, {
-        'domain': 'login.live.com',
-        'is_control': False,
-        'category': 'Communication Tools',
+        'domain': 'www.example.com',
+        'is_control': True,
+        'category': 'Control',
         'ip': '8.8.4.4',
         'is_control_ip': True,
         'date': '2021-03-15',
         'start_time': '2021-03-15T20:02:06.996014164-04:00',
-        'end_time': '2021-03-15T20:02:07.015386713-04:00',
+        'end_time': '2021-03-15T20:02:07.002365608-04:00',
         'error': None,
         'anomaly': None,
         'success': True,
         'controls_failed': False,
-        'received': {
-            'ip': '40.126.31.135'
-        },
-        'rcode': ['0', '0', '0'],
+        'received': [{
+            'ip': '93.184.216.34'
+        }],
+        'rcode': ['0'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP-Satellite-2021-03-15-12-00-01',
         'has_type_a': True
@@ -378,36 +317,44 @@ class FlattenSatelliteTest(unittest.TestCase):
         'ip': '8.8.4.4',
         'is_control_ip': True,
         'date': '2021-03-15',
-        'start_time': '2021-03-15T20:02:06.996014164-04:00',
-        'end_time': '2021-03-15T20:02:07.015386713-04:00',
+        'start_time': '2021-03-15T20:02:07.002380008-04:00',
+        'end_time': '2021-03-15T20:02:07.008908491-04:00',
         'error': None,
         'anomaly': None,
         'success': True,
         'controls_failed': False,
-        'received': {
-            'ip': '40.126.31.8'
-        },
-        'rcode': ['0', '0', '0'],
+        'received': [
+            {
+                'ip': '40.126.31.135'
+            },
+            {
+                'ip': '40.126.31.8'
+            },
+            {
+                'ip': '40.126.31.6'
+            },
+        ],
+        'rcode': ['0'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP-Satellite-2021-03-15-12-00-01',
         'has_type_a': True
     }, {
-        'domain': 'login.live.com',
-        'is_control': False,
-        'category': 'Communication Tools',
+        'domain': 'www.example.com',
+        'is_control': True,
+        'category': 'Control',
         'ip': '8.8.4.4',
         'is_control_ip': True,
         'date': '2021-03-15',
-        'start_time': '2021-03-15T20:02:06.996014164-04:00',
+        'start_time': '2021-03-15T20:02:07.008915491-04:00',
         'end_time': '2021-03-15T20:02:07.015386713-04:00',
         'error': None,
         'anomaly': None,
         'success': True,
         'controls_failed': False,
-        'received': {
-            'ip': '40.126.31.6'
-        },
-        'rcode': ['0', '0', '0'],
+        'received': [{
+            'ip': '93.184.216.34'
+        }],
+        'rcode': ['0'],
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP-Satellite-2021-03-15-12-00-01',
         'has_type_a': True
@@ -461,6 +408,167 @@ class FlattenSatelliteTest(unittest.TestCase):
 
     self.assertListEqual(results, expected)
 
+  def test_flattenmeasurement_satellite_v2p1_single(self) -> None:
+    """Test flattening of a single Satellite v2.1 measurements."""
+    filename = "CP_Satellite-2021-04-18-12-00-01/results.json"
+
+    # yapf: disable
+    line = {
+        "vp": "12.5.76.236",
+        "location": {
+            "country_name": "United States",
+            "country_code": "US"
+        },
+        "test_url": "ultimate-guitar.com",
+        "response": {
+            "rcode": ["2"]
+        },
+        "passed_control": True,
+        "connect_error": False,
+        "in_control_group": True,
+        "anomaly": True,
+        "confidence": {
+            "average": 0,
+            "matches": None,
+            "untagged_controls": False,
+            "untagged_response": False
+        },
+        "start_time": "2021-04-18 14:49:07.712972288 -0400 EDT m=+10146.644451890",
+        "end_time": "2021-04-18 14:49:07.749265765 -0400 EDT m=+10146.680745375"
+    }
+    # yapf: enable
+
+    expected = {
+        'ip': '12.5.76.236',
+        'is_control_ip': False,
+        'country': 'US',
+        'domain': 'ultimate-guitar.com',
+        'is_control': False,
+        'category': 'History arts and literature',
+        'error': None,
+        'anomaly': True,
+        'success': True,
+        'controls_failed': False,
+        'received': [],
+        'rcode': ['2'],
+        'date': '2021-04-18',
+        'start_time': '2021-04-18T14:49:07.712972288-04:00',
+        'end_time': '2021-04-18T14:49:07.749265765-04:00',
+        'source': 'CP_Satellite-2021-04-18-12-00-01',
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc'
+    }
+
+    flattener = get_satellite_flattener()
+    rows = list(
+        flattener.process_satellite(filename, line,
+                                    'ab3b0ed527334c6ba988362e6a2c98fc'))
+
+    self.assertEqual(len(rows), 1)
+    self.assertEqual(rows[0], expected)
+
+  def test_flattenmeasurement_satellite_v2p1_neg_rcode_no_error(self) -> None:
+    """Test flattening of a Satellite v2.1 measurement with a missing error."""
+    filename = "CP_Satellite-2021-04-18-12-00-01/results.json"
+
+    # yapf: disable
+    line = {
+        "vp": "109.69.144.30",
+        "location": {
+            "country_name": "Italy",
+            "country_code": "IT"
+        },
+        "test_url": "ok.ru",
+        "response": {
+            "rcode": ["-1"]
+        },
+        "passed_control": True,
+        "connect_error": False,
+        "in_control_group": True,
+        "anomaly": True,
+        "confidence": {
+            "average": 0,
+            "matches": None,
+            "untagged_controls": False,
+            "untagged_response": False
+        },
+        "start_time": "2021-04-18 14:49:01.517087379 -0400 EDT m=+10140.448566990",
+        "end_time": "2021-04-18 14:49:01.788309957 -0400 EDT m=+10140.719789564"
+    }
+    # yapf: enable
+
+    expected = {
+        'anomaly': True,
+        'category': 'News Media',
+        'controls_failed': False,
+        'country': 'IT',
+        'date': '2021-04-18',
+        'domain': 'ok.ru',
+        'end_time': '2021-04-18T14:49:01.788309957-04:00',
+        'error': None,
+        'ip': '109.69.144.30',
+        'is_control': False,
+        'is_control_ip': False,
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'rcode': ['-1'],
+        'received': [],
+        'source': 'CP_Satellite-2021-04-18-12-00-01',
+        'start_time': '2021-04-18T14:49:01.517087379-04:00',
+        'success': True
+    }
+
+    flattener = get_satellite_flattener()
+    rows = list(
+        flattener.process_satellite(filename, line,
+                                    'ab3b0ed527334c6ba988362e6a2c98fc'))
+
+    self.assertEqual(len(rows), 1)
+    self.assertEqual(rows[0], expected)
+
+  def test_flattenmeasurement_satellite_v2p1_ips_but_no_0_rcode(self) -> None:
+    """Test flattening of a Satellite v2.1 measurement with a missing 0 rcode."""
+    filename = "CP_Satellite-2021-05-16-12-00-01/results.json"
+
+    # yapf: disable
+    line = {
+        'vp': '111.164.180.5',
+        'location': {
+            'country_name': 'China',
+            'country_code': 'CN'
+        },
+        'test_url': 'protectionline.org',
+        'response': {
+            '217.70.184.55': ['ip', 'no_tags'],
+            'rcode': ['2']
+        },
+        'passed_control': True,
+        'connect_error': False,
+        'in_control_group': True,
+        'anomaly': False,
+        'confidence': {
+            'average': 100,
+            'matches': [100],
+            'untagged_controls': False,
+            'untagged_response': True
+        },
+        'start_time': '2021-05-16 14:46:57.433350046 -0400 EDT m=+10016.312771401',
+        'end_time': '2021-05-16 14:46:57.686318846 -0400 EDT m=+10016.565740205'
+    }
+    # yapf: enable
+
+    flattener = get_satellite_flattener()
+
+    with self.assertLogs() as captured:
+      rows = list(
+          flattener.process_satellite(filename, line,
+                                      'ab3b0ed527334c6ba988362e6a2c98fc'))
+
+    # This line contains an error and currently we drop the data
+    self.assertEqual(len(rows), 0)
+    self.assertEqual(len(captured.records), 1)
+    self.assertIn(
+        "Satellite v2.1 measurement has ips but no 0 rcode: CP_Satellite-2021-05-16-12-00-01/results.json",
+        captured.records[0].getMessage())
+
   def test_flattenmeasurement_satellite_v2p2(self) -> None:
     """Test flattening of Satellite v2.2 measurements."""
     filenames = [
@@ -469,6 +577,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         'gs://firehook-scans/satellite/CP-Satellite-2021-10-20-12-00-01/results.json'
     ]
 
+    # yapf: disable
     interference = [{
         "confidence": {
             "average": 100,
@@ -476,24 +585,15 @@ class FlattenSatelliteTest(unittest.TestCase):
             "untagged_controls": False,
             "untagged_response": False
         },
-        "passed_liveness":
-            True,
-        "connect_error":
-            False,
-        "in_control_group":
-            True,
-        "anomaly":
-            False,
-        "excluded":
-            False,
-        "vp":
-            "216.238.19.1",
-        "test_url":
-            "11st.co.kr",
-        "start_time":
-            "2021-10-20 14:51:41.295287198 -0400 EDT",
-        "end_time":
-            "2021-10-20 14:51:41.397573385 -0400 EDT",
+        "passed_liveness": True,
+        "connect_error": False,
+        "in_control_group": True,
+        "anomaly": False,
+        "excluded": False,
+        "vp": "216.238.19.1",
+        "test_url": "11st.co.kr",
+        "start_time": "2021-10-20 14:51:41.295287198 -0400 EDT",
+        "end_time": "2021-10-20 14:51:41.397573385 -0400 EDT",
         "exclude_reason": [],
         "location": {
             "country_name": "United States",
@@ -504,14 +604,10 @@ class FlattenSatelliteTest(unittest.TestCase):
             "has_type_a": True,
             "response": {
                 "113.217.247.90": {
-                    "http":
-                        "db2f9ca747f3e2e0896a1b783b27738fddfb4ba8f0500c0bfc0ad75e8f082090",
-                    "cert":
-                        "6908c7e0f2cc9a700ddd05efc41836da3057842a6c070cdc41251504df3735f4",
-                    "asnum":
-                        9644,
-                    "asname":
-                        "SKTELECOM-NET-AS SK Telecom",
+                    "http": "db2f9ca747f3e2e0896a1b783b27738fddfb4ba8f0500c0bfc0ad75e8f082090",
+                    "cert": "6908c7e0f2cc9a700ddd05efc41836da3057842a6c070cdc41251504df3735f4",
+                    "asnum": 9644,
+                    "asname": "SKTELECOM-NET-AS SK Telecom",
                     "matched": ["ip", "http", "cert", "asnum", "asname"]
                 }
             },
@@ -525,24 +621,15 @@ class FlattenSatelliteTest(unittest.TestCase):
             "untagged_controls": False,
             "untagged_response": False
         },
-        "passed_liveness":
-            False,
-        "connect_error":
-            False,
-        "in_control_group":
-            True,
-        "anomaly":
-            False,
-        "excluded":
-            False,
-        "vp":
-            "5.39.25.152",
-        "test_url":
-            "www.chantelle.com",
-        "start_time":
-            "2021-10-20 17:17:27.241422553 -0400 EDT",
-        "end_time":
-            "2021-10-20 17:17:27.535929324 -0400 EDT",
+        "passed_liveness": False,
+        "connect_error": False,
+        "in_control_group": True,
+        "anomaly": False,
+        "excluded": False,
+        "vp": "5.39.25.152",
+        "test_url": "www.chantelle.com",
+        "start_time": "2021-10-20 17:17:27.241422553 -0400 EDT",
+        "end_time": "2021-10-20 17:17:27.535929324 -0400 EDT",
         "exclude_reason": [],
         "location": {
             "country_name": "France",
@@ -574,91 +661,59 @@ class FlattenSatelliteTest(unittest.TestCase):
             "untagged_controls": False,
             "untagged_response": False
         },
-        "passed_liveness":
-            False,
-        "connect_error":
-            True,
-        "in_control_group":
-            True,
-        "anomaly":
-            False,
-        "excluded":
-            False,
-        "vp":
-            "62.80.182.26",
-        "test_url":
-            "alipay.com",
-        "start_time":
-            "2021-10-20 14:51:45.952255246 -0400 EDT",
-        "end_time":
-            "2021-10-20 14:51:46.865275642 -0400 EDT",
+        "passed_liveness": False,
+        "connect_error": True,
+        "in_control_group": True,
+        "anomaly": False,
+        "excluded": False,
+        "vp": "62.80.182.26",
+        "test_url": "alipay.com",
+        "start_time": "2021-10-20 14:51:45.952255246 -0400 EDT",
+        "end_time": "2021-10-20 14:51:46.865275642 -0400 EDT",
         "exclude_reason": [],
         "location": {
             "country_name": "Ukraine",
             "country_code": "UA"
         },
         "response": [{
-            "url":
-                "a.root-servers.net",
-            "has_type_a":
-                False,
+            "url": "a.root-servers.net",
+            "has_type_a": False,
             "response": {},
-            "error":
-                "read udp 141.212.123.185:6280->62.80.182.26:53: read: connection refused",
-            "rcode":
-                -1
+            "error": "read udp 141.212.123.185:6280->62.80.182.26:53: read: connection refused",
+            "rcode": -1
         }, {
-            "url":
-                "alipay.com",
-            "has_type_a":
-                False,
+            "url": "alipay.com",
+            "has_type_a": False,
             "response": {},
-            "error":
-                "read udp 141.212.123.185:61676->62.80.182.26:53: read: connection refused",
-            "rcode":
-                -1
+            "error": "read udp 141.212.123.185:61676->62.80.182.26:53: read: connection refused",
+            "rcode": -1
         }, {
-            "url":
-                "alipay.com",
-            "has_type_a":
-                False,
+            "url": "alipay.com",
+            "has_type_a": False,
             "response": {},
-            "error":
-                "read udp 141.212.123.185:15097->62.80.182.26:53: read: connection refused",
-            "rcode":
-                -1
+            "error": "read udp 141.212.123.185:15097->62.80.182.26:53: read: connection refused",
+            "rcode": -1
         }, {
-            "url":
-                "alipay.com",
-            "has_type_a":
-                False,
+            "url": "alipay.com",
+            "has_type_a": False,
             "response": {},
-            "error":
-                "read udp 141.212.123.185:45072->62.80.182.26:53: read: connection refused",
-            "rcode":
-                -1
+            "error": "read udp 141.212.123.185:45072->62.80.182.26:53: read: connection refused",
+            "rcode": -1
         }, {
-            "url":
-                "alipay.com",
-            "has_type_a":
-                False,
+            "url": "alipay.com",
+            "has_type_a": False,
             "response": {},
-            "error":
-                "read udp 141.212.123.185:36765->62.80.182.26:53: read: connection refused",
-            "rcode":
-                -1
+            "error": "read udp 141.212.123.185:36765->62.80.182.26:53: read: connection refused",
+            "rcode": -1
         }, {
-            "url":
-                "a.root-servers.net",
-            "has_type_a":
-                False,
+            "url": "a.root-servers.net",
+            "has_type_a": False,
             "response": {},
-            "error":
-                "read udp 141.212.123.185:1295->62.80.182.26:53: read: connection refused",
-            "rcode":
-                -1
+            "error": "read udp 141.212.123.185:1295->62.80.182.26:53: read: connection refused",
+            "rcode": -1
         }]
     }]
+
 
     expected = [{
         'anomaly': False,
@@ -682,19 +737,37 @@ class FlattenSatelliteTest(unittest.TestCase):
         'source': 'CP-Satellite-2021-10-20-12-00-01',
         'rcode': ['0'],
         'received': [{
-            'asname':
-                'SKTELECOM-NET-AS SK Telecom',
-            'asnum':
-                9644,
-            'cert':
-                '6908c7e0f2cc9a700ddd05efc41836da3057842a6c070cdc41251504df3735f4',
-            'http':
-                'db2f9ca747f3e2e0896a1b783b27738fddfb4ba8f0500c0bfc0ad75e8f082090',
-            'ip':
-                '113.217.247.90',
-            'matches_control':
-                'ip http cert asnum asname'
+            'asname': 'SKTELECOM-NET-AS SK Telecom',
+            'asnum': 9644,
+            'cert': '6908c7e0f2cc9a700ddd05efc41836da3057842a6c070cdc41251504df3735f4',
+            'http': 'db2f9ca747f3e2e0896a1b783b27738fddfb4ba8f0500c0bfc0ad75e8f082090',
+            'ip': '113.217.247.90',
+            'matches_control': 'ip http cert asnum asname'
         }],
+        'success': True,
+        'exclude_reason': '',
+        'excluded': False
+    }, {
+        'anomaly': False,
+        'category': 'Control',
+        'average_confidence': 0,
+        'matches_confidence': None,
+        'untagged_controls': False,
+        'untagged_response': False,
+        'controls_failed': True,
+        'country': 'FR',
+        'date': '2021-10-20',
+        'domain': 'a.root-servers.net',
+        'is_control': True,
+        'start_time': '2021-10-20T17:17:27.241422553-04:00',
+        'end_time': '2021-10-20T17:17:27.535929324-04:00',
+        'error': None,
+        'ip': '5.39.25.152',
+        'is_control_ip': False,
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
+        'rcode': ['5'],
+        'received': [],
         'success': True,
         'exclude_reason': '',
         'excluded': False
@@ -717,9 +790,57 @@ class FlattenSatelliteTest(unittest.TestCase):
         'is_control_ip': False,
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP-Satellite-2021-10-20-12-00-01',
-        'rcode': ['5', '5', '5'],
-        'received': None,
+        'rcode': ['5'],
+        'received': [],
         'success': True,
+        'exclude_reason': '',
+        'excluded': False
+    }, {
+        'anomaly': False,
+        'category': 'Control',
+        'average_confidence': 0,
+        'matches_confidence': None,
+        'untagged_controls': False,
+        'untagged_response': False,
+        'controls_failed': True,
+        'country': 'FR',
+        'date': '2021-10-20',
+        'domain': 'a.root-servers.net',
+        'is_control': True,
+        'start_time': '2021-10-20T17:17:27.241422553-04:00',
+        'end_time': '2021-10-20T17:17:27.535929324-04:00',
+        'error': None,
+        'ip': '5.39.25.152',
+        'is_control_ip': False,
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
+        'rcode': ['5'],
+        'received': [],
+        'success': True,
+        'exclude_reason': '',
+        'excluded': False
+    }, {
+        'anomaly': False,
+        'category': 'Control',
+        'average_confidence': 0,
+        'matches_confidence': None,
+        'untagged_controls': False,
+        'untagged_response': False,
+        'controls_failed': True,
+        'country': 'UA',
+        'date': '2021-10-20',
+        'domain': 'a.root-servers.net',
+        'is_control': True,
+        'end_time': '2021-10-20T14:51:46.865275642-04:00',
+        'error': 'read udp 141.212.123.185:6280->62.80.182.26:53: read: connection refused',
+        'ip': '62.80.182.26',
+        'is_control_ip': False,
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
+        'rcode': ['-1'],
+        'received': [],
+        'start_time': '2021-10-20T14:51:45.952255246-04:00',
+        'success': False,
         'exclude_reason': '',
         'excluded': False
     }, {
@@ -735,26 +856,115 @@ class FlattenSatelliteTest(unittest.TestCase):
         'domain': 'alipay.com',
         'is_control': False,
         'end_time': '2021-10-20T14:51:46.865275642-04:00',
-        'error':
-            'read udp 141.212.123.185:6280->62.80.182.26:53: read: connection '
-            'refused | read udp 141.212.123.185:61676->62.80.182.26:53: read: '
-            'connection refused | read udp '
-            '141.212.123.185:15097->62.80.182.26:53: read: connection refused | '
-            'read udp 141.212.123.185:45072->62.80.182.26:53: read: connection '
-            'refused | read udp 141.212.123.185:36765->62.80.182.26:53: read: '
-            'connection refused | read udp '
-            '141.212.123.185:1295->62.80.182.26:53: read: connection refused',
+        'error': 'read udp 141.212.123.185:61676->62.80.182.26:53: read: connection refused',
         'ip': '62.80.182.26',
         'is_control_ip': False,
         'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
         'source': 'CP-Satellite-2021-10-20-12-00-01',
-        'rcode': ['-1', '-1', '-1', '-1', '-1', '-1'],
-        'received': None,
+        'rcode': ['-1'],
+        'received': [],
+        'start_time': '2021-10-20T14:51:45.952255246-04:00',
+        'success': False,
+        'exclude_reason': '',
+        'excluded': False
+    }, {
+        'anomaly': False,
+        'category': 'E-commerce',
+        'average_confidence': 0,
+        'matches_confidence': None,
+        'untagged_controls': False,
+        'untagged_response': False,
+        'controls_failed': True,
+        'country': 'UA',
+        'date': '2021-10-20',
+        'domain': 'alipay.com',
+        'is_control': False,
+        'end_time': '2021-10-20T14:51:46.865275642-04:00',
+        'error': 'read udp 141.212.123.185:15097->62.80.182.26:53: read: connection refused',
+        'ip': '62.80.182.26',
+        'is_control_ip': False,
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
+        'rcode': ['-1'],
+        'received': [],
+        'start_time': '2021-10-20T14:51:45.952255246-04:00',
+        'success': False,
+        'exclude_reason': '',
+        'excluded': False
+    }, {
+        'anomaly': False,
+        'category': 'E-commerce',
+        'average_confidence': 0,
+        'matches_confidence': None,
+        'untagged_controls': False,
+        'untagged_response': False,
+        'controls_failed': True,
+        'country': 'UA',
+        'date': '2021-10-20',
+        'domain': 'alipay.com',
+        'is_control': False,
+        'end_time': '2021-10-20T14:51:46.865275642-04:00',
+        'error': 'read udp 141.212.123.185:45072->62.80.182.26:53: read: connection refused',
+        'ip': '62.80.182.26',
+        'is_control_ip': False,
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
+        'rcode': ['-1'],
+        'received': [],
+        'start_time': '2021-10-20T14:51:45.952255246-04:00',
+        'success': False,
+        'exclude_reason': '',
+        'excluded': False
+    }, {
+        'anomaly': False,
+        'category': 'E-commerce',
+        'average_confidence': 0,
+        'matches_confidence': None,
+        'untagged_controls': False,
+        'untagged_response': False,
+        'controls_failed': True,
+        'country': 'UA',
+        'date': '2021-10-20',
+        'domain': 'alipay.com',
+        'is_control': False,
+        'end_time': '2021-10-20T14:51:46.865275642-04:00',
+        'error': 'read udp 141.212.123.185:36765->62.80.182.26:53: read: connection refused',
+        'ip': '62.80.182.26',
+        'is_control_ip': False,
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
+        'rcode': ['-1'],
+        'received': [],
+        'start_time': '2021-10-20T14:51:45.952255246-04:00',
+        'success': False,
+        'exclude_reason': '',
+        'excluded': False
+    }, {
+        'anomaly': False,
+        'category': 'Control',
+        'average_confidence': 0,
+        'matches_confidence': None,
+        'untagged_controls': False,
+        'untagged_response': False,
+        'controls_failed': True,
+        'country': 'UA',
+        'date': '2021-10-20',
+        'domain': 'a.root-servers.net',
+        'is_control': True,
+        'end_time': '2021-10-20T14:51:46.865275642-04:00',
+        'error': 'read udp 141.212.123.185:1295->62.80.182.26:53: read: connection refused',
+        'ip': '62.80.182.26',
+        'is_control_ip': False,
+        'measurement_id': 'ab3b0ed527334c6ba988362e6a2c98fc',
+        'source': 'CP-Satellite-2021-10-20-12-00-01',
+        'rcode': ['-1'],
+        'received': [],
         'start_time': '2021-10-20T14:51:45.952255246-04:00',
         'success': False,
         'exclude_reason': '',
         'excluded': False
     }]
+    # yapf: enable
 
     flattener = get_satellite_flattener()
     results = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ disable=abstract-method, # raises false positives in beam
         fixme, # bad rule
         import-error, # raises false positives
         line-too-long, # covered by yapf
+        logging-fstring-interpolation, # not worth the optimization
         no-member, # raises false positives
         no-name-in-module, # raises false positives
         too-many-arguments, # better handled by reviewer judgement


### PR DESCRIPTION
Apologies for the size of this PR 😬  I promise >1000 of these lines are just tests. Probably the best way to understand what's happening here is to start by looking at the test cases to get a sense for what outputs we're aiming for.

This change breaks out individual DNS requests into their own rows. This works in different ways for v1, v2.1, and v2.2 data since they store different information about their measurements.

The other major internal change is how we handle received ip tagging. In the old code we split up rows per-received-ip to tag, then reconstructed (grouped) them by `measurement_id`. However that makes it impossible to separate out multiple rows per measurement, so now we're using an additional `roundtrip_id` per final output row. I've also changed some intermediate stages in the code where we were storing Dicts instead of Lists in the `received` field. Now even in intermediate stages we only store lists, which matches the final output schema.

Some changes I have not made:
- The final schema format for rcodes currently is List[str], ultimately we want it to just be Int (a single rcode) but I don't want to add on that schema change here.
- I'd also like to eventually update some of the field names in the schema to be clearer
- The received ip tagging currently works in tests, but fails when running full-size backfills. I haven't been able to get this fixed yet. Currently I plan to turn off the received ip tagging temporarily in a follow-up PR so that we're able to make faster progress on the dashboard.