### PR TITLE
Simplify received ip tagging

### DIFF
--- a/pipeline/metadata/beam_metadata.py
+++ b/pipeline/metadata/beam_metadata.py
@@ -21,7 +21,9 @@ def make_date_ip_key(row: Row) -> DateIpKey:
 
 
 def merge_metadata_with_rows(  # pylint: disable=unused-argument
-    key: DateIpKey, value: Dict[str, List[Row]]) -> Iterator[Row]:
+    key: DateIpKey,
+    value: Dict[str, List[Row]],
+    rows_pcollection_name: str = ROWS_PCOLLECION_NAME) -> Iterator[Row]:
   # pyformat: disable
   """Merge a list of rows with their corresponding metadata information.
 
@@ -34,6 +36,8 @@ def merge_metadata_with_rows(  # pylint: disable=unused-argument
        {'netblock': '1.0.0.1/24', 'asn': 13335, 'as_name': 'CLOUDFLARENET', ...}
       and row is a dict of the format {column_name, value}
        {'domain': 'test.com', 'ip': '1.1.1.1', 'success': true ...}
+    rows_pcollection_name: default ROWS_PCOLLECION_NAME
+      set if joining a pcollection with a different name
 
   Yields:
     row dict {column_name, value} containing both row and metadata cols/values
@@ -43,7 +47,7 @@ def merge_metadata_with_rows(  # pylint: disable=unused-argument
     ip_metadata = value[IP_METADATA_PCOLLECTION_NAME][0]
   else:
     ip_metadata = {}
-  rows = value[ROWS_PCOLLECION_NAME]
+  rows = value[rows_pcollection_name]
 
   for row in rows:
     new_row: Row = {}

--- a/pipeline/metadata/beam_metadata.py
+++ b/pipeline/metadata/beam_metadata.py
@@ -21,9 +21,7 @@ def make_date_ip_key(row: Row) -> DateIpKey:
 
 
 def merge_metadata_with_rows(  # pylint: disable=unused-argument
-    key: DateIpKey,
-    value: Dict[str, List[Row]],
-    rows_pcollection_name: str = ROWS_PCOLLECION_NAME) -> Iterator[Row]:
+    key: DateIpKey, value: Dict[str, List[Row]]) -> Iterator[Row]:
   # pyformat: disable
   """Merge a list of rows with their corresponding metadata information.
 
@@ -47,7 +45,7 @@ def merge_metadata_with_rows(  # pylint: disable=unused-argument
     ip_metadata = value[IP_METADATA_PCOLLECTION_NAME][0]
   else:
     ip_metadata = {}
-  rows = value[rows_pcollection_name]
+  rows = value[ROWS_PCOLLECION_NAME]
 
   for row in rows:
     new_row: Row = {}

--- a/pipeline/metadata/beam_metadata.py
+++ b/pipeline/metadata/beam_metadata.py
@@ -21,9 +21,7 @@ def make_date_ip_key(row: Row) -> DateIpKey:
 
 
 def merge_metadata_with_rows(  # pylint: disable=unused-argument
-    key: DateIpKey,
-    value: Dict[str, List[Row]],
-    field: str = None) -> Iterator[Row]:
+    key: DateIpKey, value: Dict[str, List[Row]]) -> Iterator[Row]:
   # pyformat: disable
   """Merge a list of rows with their corresponding metadata information.
 
@@ -36,7 +34,6 @@ def merge_metadata_with_rows(  # pylint: disable=unused-argument
        {'netblock': '1.0.0.1/24', 'asn': 13335, 'as_name': 'CLOUDFLARENET', ...}
       and row is a dict of the format {column_name, value}
        {'domain': 'test.com', 'ip': '1.1.1.1', 'success': true ...}
-    field: indicates a row field to update with metadata instead of the row (default).
 
   Yields:
     row dict {column_name, value} containing both row and metadata cols/values
@@ -51,14 +48,5 @@ def merge_metadata_with_rows(  # pylint: disable=unused-argument
   for row in rows:
     new_row: Row = {}
     new_row.update(row)
-    if field == 'received':
-      if new_row['received']:
-        # Double-flattened rows are stored with a single received ip in each list
-        # to be reconstructed later
-        new_row['received'][0].update(ip_metadata)
-        new_row['received'][0].pop('date', None)
-        new_row['received'][0].pop('name', None)
-        new_row['received'][0].pop('country', None)
-    else:
-      new_row.update(ip_metadata)
+    new_row.update(ip_metadata)
     yield new_row

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -240,7 +240,7 @@ def add_received_ip_tags(
   return rows_with_tags
 
 
-def unflatten_received_ip_rows(
+def _unflatten_received_ip_rows(
     rows: beam.pvalue.PCollection[Row]) -> beam.pvalue.PCollection[Row]:
   """Unflatten so that each row contains a array of answer IPs
 
@@ -274,11 +274,11 @@ def _add_satellite_tags(
   """Add tags for resolvers and answer IPs and unflatten the Satellite measurement rows.
 
     Args:
-      rows: PCollection of measurement rows
+      rows: PCollection of flattened measurement rows
       tags: PCollection of geo tag rows
 
     Returns:
-      PCollection of measurement rows containing tag information
+      PCollection of flattened measurement rows containing tag information
   """
   # PCollection[Tuple[DateIpKey,Row]]
   ips_with_metadata = (
@@ -307,7 +307,7 @@ def _add_satellite_tags(
                     'combine date partitions' >> beam.Flatten())
 
   # PCollection[Row]
-  return unflatten_received_ip_rows(rows_with_tags)
+  return rows_with_tags
 
 
 def post_processing_satellite(
@@ -509,7 +509,11 @@ def process_satellite_with_tags(
       beam.FlatMapTuple(_read_satellite_tags).with_output_types(Row))
 
   # PCollection[Row]
-  rows_with_metadata = _add_satellite_tags(received_ip_flattened_rows, tag_rows)
+  flattened_rows_with_metadata = _add_satellite_tags(received_ip_flattened_rows,
+                                                     tag_rows)
+
+  # PCollection[Row]
+  rows_with_metadata = _unflatten_received_ip_rows(flattened_rows_with_metadata)
 
   return rows_with_metadata
 

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -502,16 +502,14 @@ def add_received_ip_tags(
 
   grouped_metadata_and_received_ips = (({
       IP_METADATA_PCOLLECTION_NAME: tags_keyed_by_ip_and_date,
-      RECEIVED_IPS_PCOLLECTION_NAME: received_ips_keyed_by_ip_and_date
+      ROWS_PCOLLECION_NAME: received_ips_keyed_by_ip_and_date
   }) | 'add received ip tags: group by keys' >> beam.CoGroupByKey())
 
   # PCollection[Row] received ip row with
   received_ips_with_metadata = (
       grouped_metadata_and_received_ips |
       'add received ip tags: merge metadata with rows' >>
-      beam.FlatMapTuple(lambda key, value: merge_metadata_with_rows(
-          key, value, rows_pcollection_name=RECEIVED_IPS_PCOLLECTION_NAME)
-                       ).with_output_types(Row))
+      beam.FlatMapTuple(merge_metadata_with_rows).with_output_types(Row))
 
   # PCollection[Tuple[roundtrip_id, Row]]
   rows_keyed_by_roundtrip_id = (

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -7,7 +7,7 @@ import json
 import logging
 import pathlib
 import re
-from typing import Tuple, Dict, Any, Iterator, Iterable
+from typing import List, Tuple, Dict, Any, Iterator, Iterable
 import uuid
 
 import apache_beam as beam
@@ -457,6 +457,52 @@ def flatten_received_ips(dns_roundtrip: Row) -> Iterator[Row]:
     yield dns_roundtrip.copy()
 
 
+def _get_received_ips_with_roundtrip_id_and_date(row: Row) -> Iterable[Row]:
+  roundtrip_id = row['roundtrip_id']
+  date = row['date']
+
+
+
+  for answer in row['received']:
+    received_with_id = answer.copy()
+    received_with_id['roundtrip_id'] = roundtrip_id
+    received_with_id['date'] = date
+    yield received_with_id
+
+def set_random_roundtrip_id(row: Row) -> Row:
+  row['roundtrip_id'] = uuid.uuid4().hex
+  return row
+
+
+def _merge_tagged_answers_with_rows(key: str, value: Dict[str, List[Row]]) -> Row:
+  """
+  key: roundtrip_id
+
+  value
+    {IP_METADATA_PCOLLECTION_NAME: One element list containing a row
+     ROWS_PCOLLECION_NAME: Many element list containing tagged answer rows}
+  """
+
+  row: Row = value[IP_METADATA_PCOLLECTION_NAME][0]
+  tagged_answers: Iterable[Row] = value[ROWS_PCOLLECION_NAME][0]
+
+  from pprint import pprint
+  pprint(("row and answers", row, tagged_answers))
+
+  for untagged_answer in row['received']:
+    untagged_ip = untagged_answer['ip']
+    tagged_answer = [answer for answer in tagged_answers if answer['ip'] == untagged_ip][0]
+
+    # remove fields that were used for joining
+    tagged_answer.pop('date')
+    tagged_answer.pop('roundtrip_id')
+
+    untagged_answer.update(tagged_answer)
+
+  pprint(("row with tags added", row))
+  return row
+
+
 def process_satellite_with_tags(
     row_lines: beam.pvalue.PCollection[Tuple[str, str]],
     tag_lines: beam.pvalue.PCollection[Tuple[str, str]]
@@ -499,6 +545,68 @@ def process_satellite_with_tags(
   # This way we avoid having to multiply rows by their number of received ips
 
   # PCollection[Row] each with only a single element in the received arrays
+
+  # PCollection[Row]
+  tag_rows = (
+      tag_lines | 'tag rows' >>
+      beam.FlatMapTuple(_read_satellite_tags).with_output_types(Row))
+
+  tags_keyed_by_ip_and_date = (
+      tag_rows | 'tags: key by ips and dates' >>
+      beam.Map(lambda tag: (make_date_ip_key(tag), tag)).with_output_types(
+          Tuple[DateIpKey, Row]))
+
+  # PCollection[Row]
+  rows_with_roundtrip_id = (
+      rows | 'add roundtrip_ids' >> beam.Map(set_random_roundtrip_id).with_output_types(Row))
+
+  # PCollection[row] received ip row
+  received_ips_with_roundtrip_ip_and_date = (
+      rows_with_roundtrip_id | 'get received ips' >>
+      beam.FlatMap(_get_received_ips_with_roundtrip_id_and_date).with_output_types(Row))
+
+  # PCollection[Tuple[DateIpKey, row]] received ip row
+  received_ips_keyed_by_ip_and_date = (
+      received_ips_with_roundtrip_ip_and_date | 'received ip: key by ips and dates' >>
+      beam.Map(lambda row: (make_date_ip_key(row), row)).with_output_types(
+          Tuple[DateIpKey, Row]))
+
+  grouped_metadata_and_received_ips = (({
+      IP_METADATA_PCOLLECTION_NAME: tags_keyed_by_ip_and_date,
+      ROWS_PCOLLECION_NAME: received_ips_keyed_by_ip_and_date
+  }) | 'add received ip tags: group by keys' >> beam.CoGroupByKey())
+
+  # PCollection[Row] received ip row with
+  received_ips_with_metadata = (
+      grouped_metadata_and_received_ips |
+      'add received ip tags: merge metadata with rows' >>
+      beam.FlatMapTuple(merge_metadata_with_rows).with_output_types(Row))
+
+  # PCollection[Tuple[roundtrip_id, Row]]
+  rows_keyed_by_roundtrip_id = (
+      rows_with_roundtrip_id | 'key row by roundtrip_id' >>
+      beam.Map(lambda row:
+               (row['roundtrip_id'], row)).with_output_types(Tuple[str, Row]))
+
+  # PCollection[Tuple[roundtrip_id, List[Row]]] # received ip
+  received_ips_grouped_by_roundtrip_ip = (
+      received_ips_with_metadata | 'group received_by roundtrip' >>
+      beam.GroupBy(lambda row: row['roundtrip_id']).with_output_types(
+          Tuple[str, Iterable[Row]]))
+
+  grouped_rows_and_received_ips = (({
+      IP_METADATA_PCOLLECTION_NAME: rows_keyed_by_roundtrip_id,
+      ROWS_PCOLLECION_NAME: received_ips_grouped_by_roundtrip_ip
+  }) | 'add received ip tags: group by roundtrip' >> beam.CoGroupByKey())
+
+  # PCollection[Row] received ip row with
+  rows_with_metadata = (
+      grouped_rows_and_received_ips |
+      'add received ip tags: add tagged answers back' >>
+      beam.MapTuple(_merge_tagged_answers_with_rows).with_output_types(Row))
+
+  return rows_with_metadata
+  """
   received_ip_flattened_rows = (
       rows | 'flatten received ips' >>
       beam.FlatMap(flatten_received_ips).with_output_types(Row))
@@ -516,6 +624,7 @@ def process_satellite_with_tags(
   rows_with_metadata = _unflatten_received_ip_rows(flattened_rows_with_metadata)
 
   return rows_with_metadata
+  """
 
 
 def process_satellite_blockpages(

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -65,47 +65,6 @@ class SatelliteTest(unittest.TestCase):
     ]
     self.assertListEqual(result, expected)
 
-  def test_unflatten_satellite(self) -> None:
-    """Test unflattening satellite received ips into a single row."""
-    rows = [{
-        'ip': '1.1.1.1',
-        'domain': 'x.com',
-        'measurement_id': '33faf138-f331-43a0-b1f2-ec50ee3190d2',
-        'roundtrip_id': '58df0d3d-c374-4c01-a9b9-5174e4274cf9',
-        'received': [{
-            'ip': '0.0.0.1',
-            'tag': 'value1'
-        }]
-    }, {
-        'ip': '1.1.1.1',
-        'domain': 'x.com',
-        'measurement_id': '33faf138-f331-43a0-b1f2-ec50ee3190d2',
-        'roundtrip_id': '58df0d3d-c374-4c01-a9b9-5174e4274cf9',
-        'received': [{
-            'ip': '0.0.0.2',
-            'tag': 'value2'
-        }]
-    }]
-
-    expected = [{
-        'ip':
-            '1.1.1.1',
-        'domain':
-            'x.com',
-        'measurement_id':
-            '33faf138-f331-43a0-b1f2-ec50ee3190d2',
-        'received': [{
-            'ip': '0.0.0.1',
-            'tag': 'value1'
-        }, {
-            'ip': '0.0.0.2',
-            'tag': 'value2'
-        }]
-    }]
-
-    unflattened = list(satellite._unflatten_satellite(rows))
-    self.assertListEqual(unflattened, expected)
-
   def test_process_satellite_v1(self) -> None:  # pylint: disable=no-self-use
     """Test processing of Satellite v1 interference and tag files."""
 

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -322,7 +322,7 @@ class SatelliteTest(unittest.TestCase):
         "asnum": 25504,
         "cert": "ea6389b446002e14d21bd7fd39d4433a5356948a906634365299b79781b43e2b",
         "http": None,
-        "ip": "185.228.169.37"  # received ip tag shouldn't tag vantage point ip
+        "ip": "185.228.169.37"  # Don't tag vps with received ip tags
     }
     ]
     # yapf: enable
@@ -564,6 +564,7 @@ class SatelliteTest(unittest.TestCase):
     tag_filenames = [
         "CP_Satellite-2021-04-18-12-00-01/resolvers.json",
         "CP_Satellite-2021-04-18-12-00-01/resolvers.json",
+        "CP_Satellite-2021-04-18-12-00-01/resolvers.json",
         "CP_Satellite-2021-04-18-12-00-01/resolvers.json"
     ]
 
@@ -577,6 +578,9 @@ class SatelliteTest(unittest.TestCase):
     }, {
         "name": "rec1pubns2.ultradns.net.",
         "vp": "64.6.65.6"
+    }, {
+        "name": "example.com",
+        "vp": "204.187.13.189"  # Don't tag received ips with vp tags
     }]
     # yapf: enable
 

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -290,6 +290,7 @@ class SatelliteTest(unittest.TestCase):
         "CP_Satellite-2021-03-01-12-00-01/resolvers.json",
         "CP_Satellite-2021-03-01-12-00-01/resolvers.json",
         "CP_Satellite-2021-03-01-12-00-01/tagged_responses.json",
+        "CP_Satellite-2021-03-01-12-00-01/tagged_responses.json",
     ]
 
     # yapf: disable
@@ -317,7 +318,13 @@ class SatelliteTest(unittest.TestCase):
         "cert": "9eb21a74a3cf1ecaaf6b19253025b4ca38f182e9f1f3e7355ba3c3004d4b7a10",
         "http": "7b4b4d1bfb0a645c990f55557202f88be48e1eee0c10bdcc621c7b682bf7d2ca",
         "ip": "198.35.26.96"
-    }]
+    }, {"asname": "CRONON-AS Obermuensterstr. 9",
+        "asnum": 25504,
+        "cert": "ea6389b446002e14d21bd7fd39d4433a5356948a906634365299b79781b43e2b",
+        "http": None,
+        "ip": "185.228.169.37"  # received ip tag shouldn't tag vantage point ip
+    }
+    ]
     # yapf: enable
 
     tags = zip(tag_filenames, [json.dumps(t) for t in _tags])


### PR DESCRIPTION
Do received ip tagging using the "triple cogroup" algorithm we discussed.

Successful full backfill [here](https://pantheon.corp.google.com/dataflow/jobs/us-central1/2022-02-23_13_54_58-12382344337112806992?project=firehook-censoredplanet) (took 9 hours) Previously these backfills were failing due to OOMing workers.

I'm very hopeful this will help with performance since previously the unit tests took ~4 minutes to run, and now they take ~15 seconds.


Copying the TODO comment from the code for posterity:
```
TODO we want to change the structure here
Currently we're CoGrouping over two elements using a (date, received_ip) key
A row with flattened received ips like
 {"ip": "1.2.3.4",
  "date": "2021-01-01"
  "domain": "example.com"
  "roundtrip_id": "abc"
  "received" [{"ip": "5.6.7.8"}]
}
and metadata like
{"ip": "5.6.7.8", "date":"2021-01-01", "asn": 123}

But in the future we want to have three pieces
1. The initial row (without flattening the received ips) with a roundtrip_id
2. Information on a single received ip like:
    {"received_ip": "5.6.7.8", "date": "2021-01-01", "roundtrip_id": "abc"}
3. Metadata as above.
Then we can CoGroup 2 and 3 together by (date, received_ip)
and then Group them with 1 by roundtrip_id
and add metadata to the appropriate answers
This way we avoid having to multiply rows by their number of received ips
```