### PR TITLE
separate out blockpage processing

### DIFF
--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -31,7 +31,6 @@ from google.cloud import bigquery as cloud_bigquery  # type: ignore
 from pipeline.metadata.beam_metadata import DateIpKey, IP_METADATA_PCOLLECTION_NAME, ROWS_PCOLLECION_NAME, make_date_ip_key, merge_metadata_with_rows
 from pipeline.metadata.flatten import Row
 from pipeline.metadata import flatten_base
-from pipeline.metadata import flatten_satellite
 from pipeline.metadata import flatten
 from pipeline.metadata import satellite
 from pipeline.metadata.ip_metadata_chooser import IpMetadataChooserFactory
@@ -423,7 +422,7 @@ class ScanDataBeamPipelineRunner():
       existing_sources = []
 
     if scan_type == satellite.SCAN_TYPE_SATELLITE:
-      files_to_load = flatten_satellite.SATELLITE_FILES
+      files_to_load = satellite.SATELLITE_FILES
     else:
       files_to_load = SCAN_FILES
 

--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -19,6 +19,9 @@ from pipeline.metadata.domain_categories import DomainCategoryMatcher
 # Type definition for input responses, TODO make actual type stricter
 ResponsesEntry = Any
 
+# Rows that contain blockpages
+BlockpageRow = Row
+
 SATELLITE_TAGS = {'ip', 'http', 'asnum', 'asname', 'cert'}
 SATELLITE_V2_1_START_DATE = datetime.date(2021, 3, 1)
 SATELLITE_V2_2_START_DATE = datetime.date(2021, 6, 24)
@@ -509,7 +512,7 @@ class FlattenBlockpages(beam.DoFn):
     self.blockpage_matcher = BlockpageMatcher()
     #pylint: enable=attribute-defined-outside-init
 
-  def process(self, element: Tuple[str, str]) -> Iterator[Row]:
+  def process(self, element: Tuple[str, str]) -> Iterator[BlockpageRow]:
     (filename, line) = element
 
     try:
@@ -522,7 +525,7 @@ class FlattenBlockpages(beam.DoFn):
     yield from self._process_satellite_blockpages(scan, filename)
 
   def _process_satellite_blockpages(self, blockpage_entry: ResponsesEntry,
-                                    filepath: str) -> Iterator[Row]:
+                                    filepath: str) -> Iterator[BlockpageRow]:
     """Process a line of Satellite blockpage data.
 
     Args:
@@ -530,7 +533,7 @@ class FlattenBlockpages(beam.DoFn):
       filepath: a filepath string like "<path>/blockpages.json.gz"
 
     Yields:
-      Rows, usually 2 corresponding to the fetched http and https data respectively
+      BlockpageRows, usually 2 corresponding to the fetched http and https data
     """
     row = {
         'domain': blockpage_entry['keyword'],

--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -2,12 +2,14 @@
 
 from __future__ import absolute_import
 
+import datetime
 import json
 import logging
 import pathlib
 import re
 from typing import Optional, Dict, Any, Iterator, List, Tuple
-import datetime
+
+import apache_beam as beam
 
 from pipeline.metadata import flatten_base
 from pipeline.metadata.flatten_base import Row
@@ -21,47 +23,8 @@ SATELLITE_TAGS = {'ip', 'http', 'asnum', 'asname', 'cert'}
 SATELLITE_V2_1_START_DATE = datetime.date(2021, 3, 1)
 SATELLITE_V2_2_START_DATE = datetime.date(2021, 6, 24)
 
-# Data files for the Satellite pipeline
-SATELLITE_RESOLVERS_FILE = 'resolvers.json'  #v1, v2.2
-
-SATELLITE_RESULTS_FILE = 'results.json'  # v2.1, v2.2
-
-SATELLITE_TAGGED_ANSWERS_FILE = 'tagged_answers.json'  # v1
 SATELLITE_ANSWERS_CONTROL_FILE = 'answers_control.json'  #v1
-SATELLITE_INTERFERENCE_FILE = 'interference.json'  # v1
-SATELLITE_INTERFERENCE_ERR_FILE = 'interference_err.json'  # v1
-SATELLITE_ANSWERS_ERR_FILE = 'answers_err.json'  # v1
-
-SATELLITE_TAGGED_RESOLVERS_FILE = 'tagged_resolvers.json'  # v2.1
 SATELLITE_RESPONSES_CONTROL_FILE = 'responses_control.json'  # v2.1
-SATELLITE_TAGGED_RESPONSES = 'tagged_responses.json'  # v2.1
-
-SATELLITE_BLOCKPAGES_FILE = 'blockpages.json'  # v2.2
-
-# Files containing metadata for satellite DNS resolvers
-SATELLITE_RESOLVER_TAG_FILES = [
-    SATELLITE_RESOLVERS_FILE, SATELLITE_TAGGED_RESOLVERS_FILE
-]
-
-# Files containing metadata for satellite receives answer ips
-SATELLITE_ANSWER_TAG_FILES = [
-    SATELLITE_TAGGED_ANSWERS_FILE, SATELLITE_TAGGED_RESPONSES
-]
-
-# Files containing satellite ip metadata
-SATELLITE_TAG_FILES = SATELLITE_RESOLVER_TAG_FILES + SATELLITE_ANSWER_TAG_FILES
-
-# Files containing satellite DNS tests
-SATELLITE_OBSERVATION_FILES = [
-    SATELLITE_INTERFERENCE_FILE, SATELLITE_INTERFERENCE_ERR_FILE,
-    SATELLITE_ANSWERS_CONTROL_FILE, SATELLITE_RESPONSES_CONTROL_FILE,
-    SATELLITE_RESULTS_FILE, SATELLITE_ANSWERS_ERR_FILE
-]
-
-# All satellite files
-SATELLITE_FILES = (
-    SATELLITE_TAG_FILES + [SATELLITE_BLOCKPAGES_FILE] +
-    SATELLITE_OBSERVATION_FILES)
 
 # Component that will match every satellite filepath
 # filepaths look like
@@ -70,6 +33,21 @@ SATELLITE_PATH_COMPONENT = "Satellite"
 
 # For Satellite
 CONTROL_IPS = ['1.1.1.1', '8.8.8.8', '8.8.4.4', '64.6.64.6', '64.6.65.6']
+
+
+def get_filename(filepath: str) -> str:
+  """Get just filename from filepath
+
+  Args:
+    filepath like: "CP_Satellite-2020-12-17-12-00-01/resolvers.json.gz"
+
+  Returns:
+    base filename like "resolvers.json"
+  """
+  filename = pathlib.PurePosixPath(filepath).name
+  if '.gz' in pathlib.PurePosixPath(filename).suffixes:
+    filename = pathlib.PurePosixPath(filename).stem
+  return filename
 
 
 def format_timestamp(timestamp: str) -> str:
@@ -257,14 +235,9 @@ class SatelliteFlattener():
       Rows
     """
     date = re.findall(r'\d\d\d\d-\d\d-\d\d', filepath)[0]
+    filename = get_filename(filepath)
 
-    filename = pathlib.PurePosixPath(filepath).name
-    if '.gz' in pathlib.PurePosixPath(filename).suffixes:
-      filename = pathlib.PurePosixPath(filename).stem
-
-    if filename == SATELLITE_BLOCKPAGES_FILE:
-      yield from self._process_satellite_blockpages(responses_entry, filepath)
-    elif datetime.date.fromisoformat(date) < SATELLITE_V2_1_START_DATE:
+    if datetime.date.fromisoformat(date) < SATELLITE_V2_1_START_DATE:
       yield from self._process_satellite_v1(date, responses_entry, filepath,
                                             random_measurement_id)
     else:
@@ -454,45 +427,6 @@ class SatelliteFlattener():
       roundtrip_row['received'] = all_received
       yield roundtrip_row
 
-  def _process_satellite_blockpages(self, blockpage_entry: ResponsesEntry,
-                                    filepath: str) -> Iterator[Row]:
-    """Process a line of Satellite blockpage data.
-
-    Args:
-      blockpage_entry: a loaded json object containing the parsed content of the line
-      filepath: a filepath string like "<path>/blockpages.json.gz"
-
-    Yields:
-      Rows, usually 2 corresponding to the fetched http and https data respectively
-    """
-    row = {
-        'domain': blockpage_entry['keyword'],
-        'ip': blockpage_entry['ip'],
-        'date': blockpage_entry['start_time'][:10],
-        'start_time': format_timestamp(blockpage_entry['start_time']),
-        'end_time': format_timestamp(blockpage_entry['end_time']),
-        'success': blockpage_entry['fetched'],
-        'source': flatten_base.source_from_filename(filepath),
-    }
-
-    http = {
-        'https': False,
-    }
-    http.update(row)
-    received_fields = flatten_base.parse_received_data(
-        self.blockpage_matcher, blockpage_entry.get('http', ''), True)
-    http.update(received_fields)
-    yield http
-
-    https = {
-        'https': True,
-    }
-    https.update(row)
-    received_fields = flatten_base.parse_received_data(
-        self.blockpage_matcher, blockpage_entry.get('https', ''), True)
-    https.update(received_fields)
-    yield https
-
   def _process_satellite_v2_control(
       self, responses_entry: ResponsesEntry, filepath: str,
       random_measurement_id: str) -> Iterator[Row]:
@@ -565,3 +499,63 @@ class SatelliteFlattener():
         row['received'] = all_received
 
         yield row
+
+
+class FlattenBlockpages(beam.DoFn):
+  """DoFn class for flattening lines of blockpage text into Rows."""
+
+  def setup(self) -> None:
+    #pylint: disable=attribute-defined-outside-init
+    self.blockpage_matcher = BlockpageMatcher()
+    #pylint: enable=attribute-defined-outside-init
+
+  def process(self, element: Tuple[str, str]) -> Iterator[Row]:
+    (filename, line) = element
+
+    try:
+      scan = json.loads(line)
+    except json.decoder.JSONDecodeError as e:
+      logging.warning('JSONDecodeError: %s\nFilename: %s\n%s\n', e, filename,
+                      line)
+      return
+
+    yield from self._process_satellite_blockpages(scan, filename)
+
+  def _process_satellite_blockpages(self, blockpage_entry: ResponsesEntry,
+                                    filepath: str) -> Iterator[Row]:
+    """Process a line of Satellite blockpage data.
+
+    Args:
+      blockpage_entry: a loaded json object containing the parsed content of the line
+      filepath: a filepath string like "<path>/blockpages.json.gz"
+
+    Yields:
+      Rows, usually 2 corresponding to the fetched http and https data respectively
+    """
+    row = {
+        'domain': blockpage_entry['keyword'],
+        'ip': blockpage_entry['ip'],
+        'date': blockpage_entry['start_time'][:10],
+        'start_time': format_timestamp(blockpage_entry['start_time']),
+        'end_time': format_timestamp(blockpage_entry['end_time']),
+        'success': blockpage_entry['fetched'],
+        'source': flatten_base.source_from_filename(filepath),
+    }
+
+    http = {
+        'https': False,
+    }
+    http.update(row)
+    received_fields = flatten_base.parse_received_data(
+        self.blockpage_matcher, blockpage_entry.get('http', ''), True)
+    http.update(received_fields)
+    yield http
+
+    https = {
+        'https': True,
+    }
+    https.update(row)
+    received_fields = flatten_base.parse_received_data(
+        self.blockpage_matcher, blockpage_entry.get('https', ''), True)
+    https.update(received_fields)
+    yield https

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import datetime
 import json
 import logging
-import pathlib
 import re
 from typing import Union, List, Tuple, Dict, Any, Iterator, Iterable
 import uuid
@@ -17,6 +16,48 @@ from pipeline.metadata.flatten import Row
 from pipeline.metadata.lookup_country_code import country_name_to_code
 from pipeline.metadata import flatten_satellite
 from pipeline.metadata import flatten
+
+# Data files for the Satellite pipeline
+SATELLITE_RESOLVERS_FILE = 'resolvers.json'  #v1, v2.2
+
+SATELLITE_RESULTS_FILE = 'results.json'  # v2.1, v2.2
+
+SATELLITE_TAGGED_ANSWERS_FILE = 'tagged_answers.json'  # v1
+SATELLITE_INTERFERENCE_FILE = 'interference.json'  # v1
+SATELLITE_INTERFERENCE_ERR_FILE = 'interference_err.json'  # v1
+SATELLITE_ANSWERS_ERR_FILE = 'answers_err.json'  # v1
+
+SATELLITE_TAGGED_RESOLVERS_FILE = 'tagged_resolvers.json'  # v2.1
+
+SATELLITE_TAGGED_RESPONSES = 'tagged_responses.json'  # v2.1
+
+SATELLITE_BLOCKPAGES_FILE = 'blockpages.json'  # v2.2
+
+# Files containing metadata for satellite DNS resolvers
+SATELLITE_RESOLVER_TAG_FILES = [
+    SATELLITE_RESOLVERS_FILE, SATELLITE_TAGGED_RESOLVERS_FILE
+]
+
+# Files containing metadata for satellite receives answer ips
+SATELLITE_ANSWER_TAG_FILES = [
+    SATELLITE_TAGGED_ANSWERS_FILE, SATELLITE_TAGGED_RESPONSES
+]
+
+# Files containing satellite ip metadata
+SATELLITE_TAG_FILES = SATELLITE_RESOLVER_TAG_FILES + SATELLITE_ANSWER_TAG_FILES
+
+# Files containing satellite DNS tests
+SATELLITE_OBSERVATION_FILES = [
+    SATELLITE_INTERFERENCE_FILE, SATELLITE_INTERFERENCE_ERR_FILE,
+    flatten_satellite.SATELLITE_ANSWERS_CONTROL_FILE,
+    flatten_satellite.SATELLITE_RESPONSES_CONTROL_FILE, SATELLITE_RESULTS_FILE,
+    SATELLITE_ANSWERS_ERR_FILE
+]
+
+# All satellite files
+SATELLITE_FILES = (
+    SATELLITE_TAG_FILES + [SATELLITE_BLOCKPAGES_FILE] +
+    SATELLITE_OBSERVATION_FILES)
 
 BLOCKPAGE_BIGQUERY_SCHEMA = {
     # Columns from Censored Planet data
@@ -50,21 +91,6 @@ NUM_SATELLITE_INPUT_PARTITIONS = 4
 
 # PCollection key name used internally by the beam pipeline
 RECEIVED_IPS_PCOLLECTION_NAME = 'received_ips'
-
-
-def _get_filename(filepath: str) -> str:
-  """Get just filename from filepath
-
-  Args:
-    filepath like: "CP_Satellite-2020-12-17-12-00-01/resolvers.json.gz"
-
-  Returns:
-    base filename like "resolvers.json"
-  """
-  filename = pathlib.PurePosixPath(filepath).name
-  if '.gz' in pathlib.PurePosixPath(filename).suffixes:
-    filename = pathlib.PurePosixPath(filename).stem
-  return filename
 
 
 def _get_satellite_date_partition(row: Row, _: int) -> int:
@@ -576,15 +602,14 @@ def process_satellite_blockpages(
   """Process Satellite measurements and tags.
 
   Args:
-    blockpages: Row objects
+    blockpages: (filepath, Row) objects
 
   Returns:
     PCollection[Row] of blockpage rows in bigquery format
   """
   rows = (
       blockpages | 'flatten blockpages' >> beam.ParDo(
-          flatten.FlattenMeasurement()).with_output_types(Row))
-
+          flatten_satellite.FlattenBlockpages()).with_output_types(Row))
   return rows
 
 
@@ -594,8 +619,8 @@ def partition_satellite_input(
   """Partitions Satellite input into answer/resolver_tags, blockpages and rows.
 
   Args:
-    line: an input line Tuple[filename, line_content]
-      filename is "<path>/name.json"
+    line: an input line Tuple[filepath, line_content]
+      filepath is "<path>/name.json"
     num_partitions: number of partitions to use, always 4
 
   Returns:
@@ -614,14 +639,14 @@ def partition_satellite_input(
         "Bad input number of partitions; always use NUM_SATELLITE_INPUT_PARTITIONS."
     )
 
-  filename = _get_filename(line[0])
-  if filename in flatten_satellite.SATELLITE_ANSWER_TAG_FILES:
+  filename = flatten_satellite.get_filename(line[0])
+  if filename in SATELLITE_ANSWER_TAG_FILES:
     return 0
-  if filename in flatten_satellite.SATELLITE_RESOLVER_TAG_FILES:
+  if filename in SATELLITE_RESOLVER_TAG_FILES:
     return 1
-  if filename == flatten_satellite.SATELLITE_BLOCKPAGES_FILE:
+  if filename == SATELLITE_BLOCKPAGES_FILE:
     return 2
-  if filename in flatten_satellite.SATELLITE_OBSERVATION_FILES:
+  if filename in SATELLITE_OBSERVATION_FILES:
     return 3
   raise Exception(f"Unknown filename in Satellite data: {filename}")
 

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -4,7 +4,6 @@ import json
 import unittest
 from typing import List
 
-from pipeline.metadata.flatten_base import Row
 from pipeline.metadata.blockpage import BlockpageMatcher
 from pipeline.metadata.domain_categories import DomainCategoryMatcher
 
@@ -1145,7 +1144,7 @@ class FlattenSatelliteTest(unittest.TestCase):
     filename = 'gs://firehook-scans/satellite/CP-Satellite-2021-09-16-12-00-01/blockpages.json'
 
     # yapf: disable
-    expected_rows: List[Row] = [
+    expected_rows: List[flatten_satellite.BlockpageRow] = [
       {
         'domain': 'xvideos.com',
         'ip': '93.158.134.250',

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -1,5 +1,6 @@
 """Unit tests for satellite flattening functions"""
 
+import json
 import unittest
 from typing import List
 
@@ -17,6 +18,12 @@ def get_satellite_flattener() -> flatten_satellite.SatelliteFlattener:
   category_matcher = DomainCategoryMatcher()
   return flatten_satellite.SatelliteFlattener(blockpage_matcher,
                                               category_matcher)
+
+
+def get_blockpage_flattener() -> flatten_satellite.FlattenBlockpages:
+  flattener = flatten_satellite.FlattenBlockpages()
+  flattener.setup()
+  return flattener
 
 
 class FlattenSatelliteTest(unittest.TestCase):
@@ -1176,9 +1183,8 @@ class FlattenSatelliteTest(unittest.TestCase):
     ]
     # yapf: enable
 
-    flattener = get_satellite_flattener()
+    flattener = get_blockpage_flattener()
 
-    rows = flattener.process_satellite(filename, line,
-                                       'ab3b0ed527334c6ba988362e6a2c98fc')
+    rows = flattener.process((filename, json.dumps(line)))
 
     self.assertEqual(list(rows), expected_rows)


### PR DESCRIPTION
Split out the blockpage processing to not overlap with the code for the test/control processing. This requires giving the blockpage flattening its own DoFn class.

I initially thought I was going to also split out the test/control measurements, but on closer inspection these will actually remain the same type, just with different values in the `is_control`/`is_ip_control` fields. They're also deeply intertwined in the satellite data, sometimes stored in different files, but sometimes controls are stored inline with the test measurements.

The second commit here is adding a fake BlockpageRow type (actually just Row underneath, but distinct for documentation purposes.) Maybe that should be split off into its own PR which does the same for resolver/answer tags?