### PR TITLE
make measurement_ids permanent instead of random

### DIFF
--- a/pipeline/metadata/flatten.py
+++ b/pipeline/metadata/flatten.py
@@ -15,6 +15,9 @@ from pipeline.metadata.domain_categories import DomainCategoryMatcher
 from pipeline.metadata.flatten_satellite import SatelliteFlattener, SATELLITE_PATH_COMPONENT
 from pipeline.metadata.flatten_hyperquack import HyperquackFlattener
 
+# Randomly chosen UUID used as a namespace for generating further UUIDs
+CENSORED_PLANET_NAMESPACE = uuid.UUID('23fd299b-6547-4dca-b630-cb05dec70e0e')
+
 
 class FlattenMeasurement(beam.DoFn):
   """DoFn class for flattening lines of json text into BigqueryRow."""
@@ -59,11 +62,11 @@ class FlattenMeasurement(beam.DoFn):
       return
 
     # Add a unique id per-measurement so single retry rows can be reassembled
-    random_measurement_id = uuid.uuid4().hex
+    measurement_id = uuid.uuid5(CENSORED_PLANET_NAMESPACE, filename + line).hex
 
     if SATELLITE_PATH_COMPONENT in filename:
       yield from self.satellite_flattener.process_satellite(
-          filename, scan, random_measurement_id)
+          filename, scan, measurement_id)
     else:
       yield from self.hyperquack_flattener.process_hyperquack(
-          filename, scan, random_measurement_id)
+          filename, scan, measurement_id)

--- a/pipeline/metadata/flatten.py
+++ b/pipeline/metadata/flatten.py
@@ -15,7 +15,7 @@ from pipeline.metadata.domain_categories import DomainCategoryMatcher
 from pipeline.metadata.flatten_satellite import SatelliteFlattener, SATELLITE_PATH_COMPONENT
 from pipeline.metadata.flatten_hyperquack import HyperquackFlattener
 
-#  UUID used as a namespace for generating further UUIDs
+# UUID used as a namespace for generating further UUIDs
 CENSORED_PLANET_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_DNS, "censoredplanet.org")
 
 

--- a/pipeline/metadata/flatten.py
+++ b/pipeline/metadata/flatten.py
@@ -15,8 +15,8 @@ from pipeline.metadata.domain_categories import DomainCategoryMatcher
 from pipeline.metadata.flatten_satellite import SatelliteFlattener, SATELLITE_PATH_COMPONENT
 from pipeline.metadata.flatten_hyperquack import HyperquackFlattener
 
-# Randomly chosen UUID used as a namespace for generating further UUIDs
-CENSORED_PLANET_NAMESPACE = uuid.UUID('23fd299b-6547-4dca-b630-cb05dec70e0e')
+#  UUID used as a namespace for generating further UUIDs
+CENSORED_PLANET_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_DNS, "censoredplanet.org")
 
 
 class FlattenMeasurement(beam.DoFn):

--- a/pipeline/metadata/flatten_hyperquack.py
+++ b/pipeline/metadata/flatten_hyperquack.py
@@ -62,29 +62,26 @@ class HyperquackFlattener():
     self.category_matcher = category_matcher
 
   def process_hyperquack(self, filename: str, scan: Any,
-                         random_measurement_id: str) -> Iterator[HyperquackRow]:
+                         measurement_id: str) -> Iterator[HyperquackRow]:
     """Process a line of Echo/Discard/HTTP/S data.
 
     Args:
       filename: a filepath string
       scan: a loaded json object containing the parsed content of the line
-      random_measurement_id: a hex id identifying this individual measurement
+      measurement_id: a hex id identifying this individual measurement
 
     Yields:
       Rows
     """
     if 'Server' in scan:
-      yield from self._process_hyperquack_v1(filename, scan,
-                                             random_measurement_id)
+      yield from self._process_hyperquack_v1(filename, scan, measurement_id)
     elif 'vp' in scan:
-      yield from self._process_hyperquack_v2(filename, scan,
-                                             random_measurement_id)
+      yield from self._process_hyperquack_v2(filename, scan, measurement_id)
     else:
       raise Exception(f"Line with unknown hyperquack format:\n{scan}")
 
-  def _process_hyperquack_v1(
-      self, filename: str, scan: Any,
-      random_measurement_id: str) -> Iterator[HyperquackRow]:
+  def _process_hyperquack_v1(self, filename: str, scan: Any,
+                             measurement_id: str) -> Iterator[HyperquackRow]:
     """Process a line of Echo/Discard/HTTP/S data in HyperQuack V1 format.
 
     https://github.com/censoredplanet/censoredplanet/blob/master/docs/hyperquackv1.rst
@@ -92,7 +89,7 @@ class HyperquackFlattener():
     Args:
       filename: a filepath string
       scan: a loaded json object containing the parsed content of the line
-      random_measurement_id: a hex id identifying this individual measurement
+      measurement_id: a hex id identifying this individual measurement
 
     Yields:
       Rows
@@ -126,7 +123,7 @@ class HyperquackFlattener():
           stateful_block=scan['StatefulBlock'],
           is_control=is_control,
           controls_failed=scan['FailSanity'],
-          measurement_id=random_measurement_id,
+          measurement_id=measurement_id,
           source=flatten_base.source_from_filename(filename))
 
       if 'Received' in result:
@@ -140,9 +137,8 @@ class HyperquackFlattener():
 
       yield row
 
-  def _process_hyperquack_v2(
-      self, filename: str, scan: Any,
-      random_measurement_id: str) -> Iterator[HyperquackRow]:
+  def _process_hyperquack_v2(self, filename: str, scan: Any,
+                             measurement_id: str) -> Iterator[HyperquackRow]:
     """Process a line of Echo/Discard/HTTP/S data in HyperQuack V2 format.
 
     https://github.com/censoredplanet/censoredplanet/blob/master/docs/hyperquackv2.rst
@@ -150,7 +146,7 @@ class HyperquackFlattener():
     Args:
       filename: a filepath string
       scan: a loaded json object containing the parsed content of the line
-      random_measurement_id: a hex id identifying this individual measurement
+      measurement_id: a hex id identifying this individual measurement
 
     Yields:
       Rows
@@ -172,7 +168,7 @@ class HyperquackFlattener():
           stateful_block=scan['stateful_block'],
           is_control=is_control,
           controls_failed=scan.get('controls_failed', None),
-          measurement_id=random_measurement_id,
+          measurement_id=measurement_id,
           source=flatten_base.source_from_filename(filename),
       )
 

--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -228,13 +228,13 @@ class SatelliteFlattener():
     self.category_matcher = category_matcher
 
   def process_satellite(self, filepath: str, responses_entry: ResponsesEntry,
-                        random_measurement_id: str) -> Iterator[SatelliteRow]:
+                        measurement_id: str) -> Iterator[SatelliteRow]:
     """Process a line of Satellite data.
 
     Args:
       filepath: a filepath string
       responses_entry: a loaded json object containing the parsed content of the line
-      random_measurement_id: a hex id identifying this individual measurement
+      measurement_id: a hex id identifying this individual measurement
 
     Yields:
       SatelliteRow
@@ -244,18 +244,18 @@ class SatelliteFlattener():
 
     if datetime.date.fromisoformat(date) < SATELLITE_V2_1_START_DATE:
       yield from self._process_satellite_v1(date, responses_entry, filepath,
-                                            random_measurement_id)
+                                            measurement_id)
     else:
       if filename == SATELLITE_RESPONSES_CONTROL_FILE:
         yield from self._process_satellite_v2_control(responses_entry, filepath,
-                                                      random_measurement_id)
+                                                      measurement_id)
       else:
         yield from self._process_satellite_v2(responses_entry, filepath,
-                                              random_measurement_id)
+                                              measurement_id)
 
-  def _process_satellite_v1(
-      self, date: str, responses_entry: ResponsesEntry, filepath: str,
-      random_measurement_id: str) -> Iterator[SatelliteRow]:
+  def _process_satellite_v1(self, date: str, responses_entry: ResponsesEntry,
+                            filepath: str,
+                            measurement_id: str) -> Iterator[SatelliteRow]:
     """Process a line of Satellite data.
 
     Args:
@@ -265,7 +265,7 @@ class SatelliteFlattener():
         <path>/answers_control.json
         <path>/interference.json
         also potentially .gz files
-      random_measurement_id: a hex id identifying this individual measurement
+      measurement_id: a hex id identifying this individual measurement
 
     Yields:
       SatelliteRow
@@ -288,7 +288,7 @@ class SatelliteFlattener():
         success='error' not in responses_entry,
         received=[],
         rcode=0 if 'error' not in responses_entry else -1,
-        measurement_id=random_measurement_id,
+        measurement_id=measurement_id,
         source=flatten_base.source_from_filename(filepath),
     )
 
@@ -301,15 +301,15 @@ class SatelliteFlattener():
     received_ips = responses_entry.get('answers')
     yield from _annotate_received_ips_v1(row, received_ips)
 
-  def _process_satellite_v2(
-      self, responses_entry: ResponsesEntry, filepath: str,
-      random_measurement_id: str) -> Iterator[SatelliteRow]:
+  def _process_satellite_v2(self, responses_entry: ResponsesEntry,
+                            filepath: str,
+                            measurement_id: str) -> Iterator[SatelliteRow]:
     """Process a line of Satellite v2 data.
 
     Args:
       responses_entry: a loaded json object containing the parsed content of the line
       filepath: path like "<path>/<filename>.json.gz"
-      random_measurement_id: a hex id identifying this individual measurement
+      measurement_id: a hex id identifying this individual measurement
 
     Yields:
       SatelliteRow
@@ -331,7 +331,7 @@ class SatelliteFlattener():
         anomaly=responses_entry['anomaly'],
         success=not responses_entry['connect_error'],
         received=[],
-        measurement_id=random_measurement_id,
+        measurement_id=measurement_id,
         source=flatten_base.source_from_filename(filepath),
         ip_metadata=IpMetadata(
             country=responses_entry.get('location', {}).get('country_code'),))
@@ -411,13 +411,13 @@ class SatelliteFlattener():
 
   def _process_satellite_v2_control(
       self, responses_entry: ResponsesEntry, filepath: str,
-      random_measurement_id: str) -> Iterator[SatelliteRow]:
+      measurement_id: str) -> Iterator[SatelliteRow]:
     """Process a line of Satellite ip control data.
 
       Args:
         responses_entry: a loaded json object containing the parsed content of the line
         filepath: path like "<path>/responses_control.json.gz"
-        random_measurement_id: a hex id identifying this individual measurement
+        measurement_id: a hex id identifying this individual measurement
 
       Yields:
         SatelliteRow
@@ -442,7 +442,7 @@ class SatelliteFlattener():
           controls_failed=not responses_entry['passed_control'],
           rcode=response['rcode'],
           has_type_a=response['has_type_a'],
-          measurement_id=random_measurement_id,
+          measurement_id=measurement_id,
           source=flatten_base.source_from_filename(filepath),
       )
 

--- a/pipeline/metadata/test_flatten.py
+++ b/pipeline/metadata/test_flatten.py
@@ -57,7 +57,7 @@ class FlattenMeasurementTest(unittest.TestCase):
         end_time='2020-11-14T07:54:49.279150352-05:00',
         ip='146.112.62.39',
         is_control=False,
-        measurement_id='',
+        measurement_id='74897db64fb45a848facb4ee40f7a00e',
         source='CP_Quack-echo-2019-10-16-01-01-17',
         start_time='2020-11-14T07:54:49.246304766-05:00',
         stateful_block=False,
@@ -67,9 +67,6 @@ class FlattenMeasurementTest(unittest.TestCase):
     flattener.setup()
 
     row = list(flattener.process((filename, line)))[0]
-    # Measurement ids are random, so we can't test them.
-    row.measurement_id = ''
-
     self.assertEqual(row, expected_row)
 
   def test_flattenmeasurement_satellite(self) -> None:
@@ -104,14 +101,11 @@ class FlattenMeasurementTest(unittest.TestCase):
                 ip='151.101.1.184', matches_control='ip http cert asnum asname')
         ],
         rcode=0,
-        measurement_id='',
+        measurement_id='87a324f6c03150dda81c93bdeddb4adf',
         source='CP_Satellite-2020-09-02-12-00-01')
 
     flattener = flatten.FlattenMeasurement()
     flattener.setup()
 
     row = list(flattener.process((filename, line)))[0]
-    # Measurement ids are random, so we can't test them.
-    row.measurement_id = ''
-
     self.assertEqual(row, expected_row)

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -13,11 +13,6 @@ from pipeline.metadata import satellite
 # pylint: disable=too-many-lines
 
 
-def _unset_measurement_id(row: SatelliteRow) -> SatelliteRow:
-  row.measurement_id = ''
-  return row
-
-
 class SatelliteTest(unittest.TestCase):
   """Unit tests for satellite steps."""
 
@@ -234,7 +229,7 @@ class SatelliteTest(unittest.TestCase):
         )],
         date = '2020-09-02',
         source = 'CP_Satellite-2020-09-02-12-00-01',
-        measurement_id = '',
+        measurement_id = 'baa7c6c8ad7b5774832fb7537943c2b0',
         ip_metadata = IpMetadata(
             country = 'US',
             name = 'special',
@@ -256,7 +251,7 @@ class SatelliteTest(unittest.TestCase):
         )],
         date = '2020-09-02',
         source = 'CP_Satellite-2020-09-02-12-00-01',
-        measurement_id = '',
+        measurement_id = '7a003222d96557a9ad2b658bc025ea79',
         ip_metadata = IpMetadata(
             country = 'US',
             name = 'special',
@@ -270,13 +265,8 @@ class SatelliteTest(unittest.TestCase):
           resolver_tags)
       answer_tag_lines = p | 'create answer tags' >> beam.Create(answer_tags)
 
-      tagged = satellite.process_satellite_with_tags(row_lines,
-                                                     answer_tag_lines,
-                                                     resolver_tag_lines)
-      # Measurement ids are random and can't be tested
-      final = tagged | 'unset measurement ids' >> beam.Map(
-          _unset_measurement_id)
-
+      final = satellite.process_satellite_with_tags(row_lines, answer_tag_lines,
+                                                    resolver_tag_lines)
       beam_test_util.assert_that(final, beam_test_util.equal_to(expected))
 
   def test_process_satellite_v2p0(self) -> None:  # pylint: disable=no-self-use
@@ -412,7 +402,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-03-01T12:43:25.3438285-05:00',
         end_time = '2021-03-01T12:43:25.3696119-05:00',
         source = 'CP_Satellite-2021-03-01-12-00-01',
-        measurement_id = '',
+        measurement_id = 'faf6d14d2b765c1e8e22724c57230361',
         ip_metadata = IpMetadata(
             country = 'IE',
             name = 'customfilter37-dns2.cleanbrowsing.org.',
@@ -433,7 +423,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-03-01T12:43:25.3438285-05:00',
         end_time = '2021-03-01T12:43:25.3696119-05:00',
         source = 'CP_Satellite-2021-03-01-12-00-01',
-        measurement_id = '',
+        measurement_id = 'faf6d14d2b765c1e8e22724c57230361',
         ip_metadata = IpMetadata(
             country = 'IE',
             name = 'customfilter37-dns2.cleanbrowsing.org.',
@@ -464,7 +454,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-03-01T12:43:25.3438285-05:00',
         end_time = '2021-03-01T12:43:25.3696119-05:00',
         source = 'CP_Satellite-2021-03-01-12-00-01',
-        measurement_id = '',
+        measurement_id = 'faf6d14d2b765c1e8e22724c57230361',
         ip_metadata = IpMetadata(
             country = 'IE',
             name = 'customfilter37-dns2.cleanbrowsing.org.',
@@ -485,7 +475,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-03-01T12:43:25.3438285-05:00',
         end_time = '2021-03-01T12:43:25.3696119-05:00',
         source = 'CP_Satellite-2021-03-01-12-00-01',
-        measurement_id = '',
+        measurement_id = '180143e90b5e5082a21f440b4482e78c',
         ip_metadata = IpMetadata(
             country = 'US',
             name = 'rdns37b.ultradns.net.',
@@ -509,7 +499,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-03-01T12:43:25.3438285-05:00',
         end_time = '2021-03-01T12:43:25.3696119-05:00',
         source = 'CP_Satellite-2021-03-01-12-00-01',
-        measurement_id = '',
+        measurement_id = '180143e90b5e5082a21f440b4482e78c',
         ip_metadata = IpMetadata(
             country = 'US',
             name = 'rdns37b.ultradns.net.',
@@ -523,13 +513,8 @@ class SatelliteTest(unittest.TestCase):
           resolver_tags)
       answer_tag_lines = p | 'create answer tags' >> beam.Create(answer_tags)
 
-      tagged = satellite.process_satellite_with_tags(row_lines,
-                                                     answer_tag_lines,
-                                                     resolver_tag_lines)
-      # Measurement ids are random and can't be tested
-      final = tagged | 'unset measurement ids' >> beam.Map(
-          _unset_measurement_id)
-
+      final = satellite.process_satellite_with_tags(row_lines, answer_tag_lines,
+                                                    resolver_tag_lines)
       beam_test_util.assert_that(final, beam_test_util.equal_to(expected))
 
   def test_process_satellite_v2p1(self) -> None:  # pylint: disable=no-self-use
@@ -683,7 +668,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-04-18T14:49:01.62448452-04:00',
         end_time = '2021-04-18T14:49:03.624563629-04:00',
         source = 'CP_Satellite-2021-04-18-12-00-01',
-        measurement_id = '',
+        measurement_id = '0590413e5980581891beec5c6a80425c',
         ip_metadata = IpMetadata(
             country = 'RU',
             name = '87-119-233-243.saransk.ru.',
@@ -704,7 +689,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-04-18T14:49:07.712972288-04:00',
         end_time = '2021-04-18T14:49:07.749265765-04:00',
         source = 'CP_Satellite-2021-04-18-12-00-01',
-        measurement_id = '',
+        measurement_id = 'f1c72aa0a7bd5368af0d3f28732da6fe',
         ip_metadata = IpMetadata(
             country = 'US',
             name = 'ns1327.ztomy.com.',
@@ -728,7 +713,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-04-18T14:51:57.561175746-04:00',
         end_time = '2021-04-18T14:51:57.587097567-04:00',
         source = 'CP_Satellite-2021-04-18-12-00-01',
-        measurement_id = '',
+        measurement_id = '6df37f5f0e9e58e58d3a6019880efafb',
         ip_metadata = IpMetadata(
             name = 'rec1pubns2.ultradns.net.',
         )
@@ -751,7 +736,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-04-18T14:51:57.587109091-04:00',
         end_time = '2021-04-18T14:51:57.61294601-04:00',
         source = 'CP_Satellite-2021-04-18-12-00-01',
-        measurement_id = '',
+        measurement_id = '6df37f5f0e9e58e58d3a6019880efafb',
         ip_metadata = IpMetadata(
             name = 'rec1pubns2.ultradns.net.',
         )
@@ -774,7 +759,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-04-18T14:51:45.836310062-04:00',
         end_time = '2021-04-18T14:51:45.862080031-04:00',
         source = 'CP_Satellite-2021-04-18-12-00-01',
-        measurement_id = '',
+        measurement_id = '2697a4f148a553f0bcdc4d6a67af5c56',
         ip_metadata = IpMetadata(
             name = 'rec1pubns2.ultradns.net.',
         )
@@ -795,7 +780,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-04-18T14:51:45.862091022-04:00',
         end_time = '2021-04-18T14:51:47.862170832-04:00',
         source = 'CP_Satellite-2021-04-18-12-00-01',
-        measurement_id = '',
+        measurement_id = '2697a4f148a553f0bcdc4d6a67af5c56',
         ip_metadata = IpMetadata(
             name = 'rec1pubns2.ultradns.net.',
         )
@@ -818,7 +803,7 @@ class SatelliteTest(unittest.TestCase):
         start_time = '2021-04-18T14:51:47.862183185-04:00',
         end_time = '2021-04-18T14:51:48.162724942-04:00',
         source = 'CP_Satellite-2021-04-18-12-00-01',
-        measurement_id = '',
+        measurement_id = '2697a4f148a553f0bcdc4d6a67af5c56',
         ip_metadata = IpMetadata(
             name = 'rec1pubns2.ultradns.net.',
         )
@@ -831,13 +816,8 @@ class SatelliteTest(unittest.TestCase):
           resolver_tags)
       answer_tag_lines = p | 'create answer tags' >> beam.Create([])
 
-      tagged = satellite.process_satellite_with_tags(row_lines,
-                                                     answer_tag_lines,
-                                                     resolver_tag_lines)
-      # Measurement ids are random and can't be tested
-      final = tagged | 'unset measurement ids' >> beam.Map(
-          _unset_measurement_id)
-
+      final = satellite.process_satellite_with_tags(row_lines, answer_tag_lines,
+                                                    resolver_tag_lines)
       beam_test_util.assert_that(final, beam_test_util.equal_to(expected))
 
   def test_process_satellite_v2p2(self) -> None:  # pylint: disable=no-self-use
@@ -1009,7 +989,7 @@ class SatelliteTest(unittest.TestCase):
         error = None,
         anomaly = False,
         success = True,
-        measurement_id = '',
+        measurement_id = '6100ab464f425e3c9cdb52db36d45519',
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = False,
         average_confidence = 100,
@@ -1052,7 +1032,7 @@ class SatelliteTest(unittest.TestCase):
         error = None,
         anomaly = True,
         success = False,
-        measurement_id = '',
+        measurement_id = '6d419dab07565bad901aabcc8d2e0cc7',
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = False,
         average_confidence = None,
@@ -1079,7 +1059,7 @@ class SatelliteTest(unittest.TestCase):
         error = 'read udp 141.212.123.185:30437->62.80.182.26:53: read: connection refused',
         anomaly = False,
         success = False,
-        measurement_id = '',
+        measurement_id = '47de079652ca53f7bdb57ca956e1c70e',
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = True,
         average_confidence = None,
@@ -1106,7 +1086,7 @@ class SatelliteTest(unittest.TestCase):
         error = 'read udp 141.212.123.185:23315->62.80.182.26:53: read: connection refused',
         anomaly = False,
         success = False,
-        measurement_id = '',
+        measurement_id = '47de079652ca53f7bdb57ca956e1c70e',
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = True,
         average_confidence = None,
@@ -1133,7 +1113,7 @@ class SatelliteTest(unittest.TestCase):
         error = 'read udp 141.212.123.185:53501->62.80.182.26:53: read: connection refused',
         anomaly = False,
         success = False,
-        measurement_id = '',
+        measurement_id = '47de079652ca53f7bdb57ca956e1c70e',
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = True,
         average_confidence = None,
@@ -1156,13 +1136,8 @@ class SatelliteTest(unittest.TestCase):
           resolver_tags)
       answer_tag_lines = p | 'create answer tags' >> beam.Create([])
 
-      tagged = satellite.process_satellite_with_tags(row_lines,
-                                                     answer_tag_lines,
-                                                     resolver_tag_lines)
-      # Measurement ids are random and can't be tested
-      final = tagged | 'unset measurement ids' >> beam.Map(
-          _unset_measurement_id)
-
+      final = satellite.process_satellite_with_tags(row_lines, answer_tag_lines,
+                                                    resolver_tag_lines)
       beam_test_util.assert_that(final, beam_test_util.equal_to(expected))
 
   def test_partition_satellite_input(self) -> None:  # pylint: disable=no-self-use


### PR DESCRIPTION
Small change that's been on my mind.

Currently we generate the measurement ids randomly and they change every time we re-run the pipeline. This instead generates them from a SHA1 hash of the filename + the measurement line, so they'll be stable across backfills. This is to potentially enable some far-future project where users can view full measurements from a permanent url.

I've used the string representation instead of the parsed json or just picking some fields since I think the string representation will be stable and unique when hashed, whereas something like the json might be sensitive to python implementation changes.

The inclusion of the filename is to make sure ids are unique across scans. I don't think scans can really generate duplicate lines (because of the unique date field) but better safe than sorry. Am I missing any other source of potential duplicate ids?