### PR TITLE
fix dns page response error parsing

### DIFF
--- a/pipeline/metadata/beam_metadata.py
+++ b/pipeline/metadata/beam_metadata.py
@@ -200,7 +200,9 @@ def merge_page_fetches_with_answers(
 
   for (roundtrip_id, answer) in answers:
     if https_page_fetches:
+      answer.https_error = https_page_fetches[0].error
       answer.https_response = https_page_fetches[0].received
     if http_page_fetches:
+      answer.http_error = http_page_fetches[0].error
       answer.http_response = http_page_fetches[0].received
     yield (roundtrip_id, answer)

--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -512,14 +512,20 @@ class FlattenBlockpages(beam.DoFn):
 
     http_row = deepcopy(row)
     http_row.https = False
-    received_fields = flatten_base.parse_received_data(
-        self.blockpage_matcher, blockpage_entry.get('http', ''), True)
-    http_row.received = received_fields
+    received = blockpage_entry.get('http', None)
+    if isinstance(received, str):
+      http_row.error = received
+    if isinstance(received, dict):
+      http_row.received = flatten_base.parse_received_data(
+          self.blockpage_matcher, received, True)
     yield http_row
 
     https_row = deepcopy(row)
     https_row.https = True
-    received_fields = flatten_base.parse_received_data(
-        self.blockpage_matcher, blockpage_entry.get('https', ''), True)
-    https_row.received = received_fields
+    received = blockpage_entry.get('https', None)
+    if isinstance(received, str):
+      https_row.error = received
+    if isinstance(received, dict):
+      https_row.received = flatten_base.parse_received_data(
+          self.blockpage_matcher, received, True)
     yield https_row

--- a/pipeline/metadata/schema.py
+++ b/pipeline/metadata/schema.py
@@ -87,7 +87,9 @@ class SatelliteAnswer():
 
   ip_metadata: IpMetadata = dataclasses.field(default_factory=IpMetadata)
   http_response: Optional[HttpsResponse] = None
+  http_error: Optional[str] = None
   https_response: Optional[HttpsResponse] = None
+  https_error: Optional[str] = None
 
 
 @dataclass
@@ -174,6 +176,7 @@ class PageFetchRow():
   success: Optional[bool] = None
   https: Optional[bool] = None
   source: Optional[str] = None
+  error: Optional[str] = None
 
 
 def flatten_for_bigquery(
@@ -272,12 +275,14 @@ def flatten_for_bigquery_satellite(row: SatelliteRow) -> Dict[str, Any]:
         'asnum': received_answer.ip_metadata.asn,
         'asname': received_answer.ip_metadata.as_name,
         # HTTP
+        'http_error': received_answer.http_error,
         'http_response_status': http_response.status,
         'http_response_headers': http_response.headers,
         'http_response_body': http_response.body,
         'http_response_page_signature': http_response.page_signature,
         'http_response_is_known_blockpage': http_response.is_known_blockpage,
         # HTTPS
+        'https_error': received_answer.https_error,
         'https_response_tls_version': https_response.tls_version,
         'https_response_tls_cipher_suite': https_response.tls_cipher_suite,
         'https_response_tls_cert': https_response.tls_cert,

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -1183,7 +1183,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         success = True,
         source = 'CP-Satellite-2021-09-16-12-00-01',
         https = False,
-        received=HttpsResponse(
+        received = HttpsResponse(
             status = '302 Moved Temporarily',
             body = '<html>\r\n<head><title>302 Found</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>302 Found</h1></center>\r\n<hr><center>nginx/1.10.3 (Ubuntu)</center>\r\n</body>\r\n</html>\r\n',
             headers = [
@@ -1206,11 +1206,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         success = True,
         source = 'CP-Satellite-2021-09-16-12-00-01',
         https = True,
-        received=HttpsResponse(
-            is_known_blockpage = None,
-            status = 'Get \"https://93.158.134.250:443/\": tls: oversized record received with length 20527',
-            page_signature = None
-        )
+        error = 'Get \"https://93.158.134.250:443/\": tls: oversized record received with length 20527',
       ),
     ]
     # yapf: enable


### PR DESCRIPTION
We were accidentally parsing the DNS HTTP/S response page errors into the `http_received_status` and `https_received_status` fields. This parses them into their own `http_error` and `https_error` fields.