### PR TITLE
move matches_confidence to answers

### DIFF
--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -390,25 +390,26 @@ class SatelliteFlattener():
       if answers:  # confidence only corresponds to fields with received ips
         roundtrip_row.average_confidence = responses_entry.get(
             'confidence')['average']
-        roundtrip_row.matches_confidence = responses_entry.get(
-            'confidence')['matches']
+        matches_confidence = responses_entry.get('confidence')['matches']
+        all_received = []
 
-      all_received = []
-      for (ip, answer) in answers.items():
-        received = SatelliteAnswer(
-            ip=ip,
-            http=answer.get('http'),
-            cert=answer.get('cert'),
-            matches_control='',
-            ip_metadata=IpMetadata(
-                as_name=answer.get('asname'),
-                asn=answer.get('asnum'),
-            ))
-        matched = answer.get('matched', [])
-        if matched:
-          received.matches_control = _append_tags(matched)
-        all_received.append(received)
-      roundtrip_row.received = all_received
+        for ((ip, answer), match_confidence) in zip(answers.items(),
+                                                    matches_confidence):
+          received = SatelliteAnswer(
+              ip=ip,
+              http=answer.get('http'),
+              cert=answer.get('cert'),
+              matches_control='',
+              match_confidence=match_confidence,
+              ip_metadata=IpMetadata(
+                  as_name=answer.get('asname'),
+                  asn=answer.get('asnum'),
+              ))
+          matched = answer.get('matched', [])
+          if matched:
+            received.matches_control = _append_tags(matched)
+          all_received.append(received)
+        roundtrip_row.received = all_received
       yield roundtrip_row
 
   def _process_satellite_v2_control(

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -723,12 +723,13 @@ def _calculate_confidence(scan: SatelliteRow,
       scan SatelliteRow with new records:
         'average_confidence':
           average percentage of tags that match control queries
-        'matches_confidence': array of percentage match per answer IP
         'untagged_controls': True if all control IPs have no tags
         'untagged_response': True if all answer IPs have no tags
+
+        'match_confidence' in answer records, percentage match per answer IP
   """
   scan.average_confidence = 0
-  scan.matches_confidence = []
+  matches_confidence = []
   scan.untagged_controls = num_control_tags == 0
   scan.untagged_response = True
 
@@ -767,11 +768,11 @@ def _calculate_confidence(scan: SatelliteRow,
         ip_match = 0.0
       else:
         ip_match = matching_tags * 100 / total_tags
-    scan.matches_confidence.append(ip_match)
+    answer.match_confidence = ip_match
+    matches_confidence.append(ip_match)
 
-  if len(scan.matches_confidence) > 0:
-    scan.average_confidence = sum(scan.matches_confidence) / len(
-        scan.matches_confidence)
+  if len(matches_confidence) > 0:
+    scan.average_confidence = sum(matches_confidence) / len(matches_confidence)
   # Sanity check for untagged responses: do not claim interference
   if scan.untagged_response:
     scan.anomaly = False

--- a/pipeline/metadata/schema.py
+++ b/pipeline/metadata/schema.py
@@ -84,6 +84,7 @@ class SatelliteAnswer():
   http: Optional[str] = None
   cert: Optional[str] = None
   matches_control: Optional[str] = None
+  match_confidence: Optional[float] = None
 
   ip_metadata: IpMetadata = dataclasses.field(default_factory=IpMetadata)
   http_response: Optional[HttpsResponse] = None
@@ -111,6 +112,8 @@ def merge_satellite_answers(base: SatelliteAnswer,
     base.cert = new.cert
   if new.matches_control is not None:
     base.matches_control = new.matches_control
+  if new.match_confidence is not None:
+    base.match_confidence = new.match_confidence
 
   if new.http_response is not None:
     base.http_response = new.http_response
@@ -160,7 +163,6 @@ class SatelliteRow(BigqueryRow):
   exclude_reason: Optional[str] = None
   has_type_a: Optional[bool] = None
   received: List[SatelliteAnswer] = dataclasses.field(default_factory=list)
-  matches_confidence: List[float] = dataclasses.field(default_factory=list)
 
 
 @dataclass
@@ -243,7 +245,6 @@ def flatten_for_bigquery_satellite(row: SatelliteRow) -> Dict[str, Any]:
       'is_control_ip': row.is_control_ip,
       'rcode': row.rcode,
       'average_confidence': row.average_confidence,
-      'matches_confidence': row.matches_confidence,
       'untagged_controls': row.untagged_controls,
       'untagged_response': row.untagged_response,
       'excluded': row.excluded,
@@ -269,6 +270,7 @@ def flatten_for_bigquery_satellite(row: SatelliteRow) -> Dict[str, Any]:
         'http': received_answer.http,
         'cert': received_answer.cert,
         'matches_control': received_answer.matches_control,
+        'match_confidence': received_answer.match_confidence,
         # Ip Metadata
         'asnum': received_answer.ip_metadata.asn,
         'asname': received_answer.ip_metadata.as_name,
@@ -369,6 +371,7 @@ SATELLITE_BIGQUERY_SCHEMA = _add_schemas(
                 'http': ('string', 'nullable'),
                 'cert': ('string', 'nullable'),
                 'matches_control': ('string', 'nullable'),
+                'match_confidence': ('float', 'nullable'),
                 # HTTP
                 'http_error': ('string', 'nullable'),
                 'http_analysis_is_known_blockpage': ('boolean', 'nullable'),
@@ -389,7 +392,6 @@ SATELLITE_BIGQUERY_SCHEMA = _add_schemas(
             }),
         'rcode': ('integer', 'nullable'),
         'average_confidence': ('float', 'nullable'),
-        'matches_confidence': ('float', 'repeated'),
         'untagged_controls': ('boolean', 'nullable'),
         'untagged_response': ('boolean', 'nullable'),
         'excluded': ('boolean', 'nullable'),

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -372,6 +372,7 @@ class FlattenSatelliteTest(unittest.TestCase):
                 SatelliteAnswer(
                     ip='88.212.202.9',
                     matches_control='ip http cert asnum asname',
+                    match_confidence=100,
                     http=
                     '8351c0267c2cd7866ff04c04261f06cd75af9a7130aac848ca43fd047404e229',
                     cert=
@@ -380,7 +381,6 @@ class FlattenSatelliteTest(unittest.TestCase):
             ],
             rcode=0,
             average_confidence=100,
-            matches_confidence=[100],
             untagged_controls=False,
             untagged_response=False,
             excluded=False,
@@ -711,7 +711,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'E-commerce',
         average_confidence = 100,
-        matches_confidence = [100],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = False,
@@ -730,6 +729,7 @@ class FlattenSatelliteTest(unittest.TestCase):
         received = [SatelliteAnswer(
             ip = '113.217.247.90',
             matches_control = 'ip http cert asnum asname',
+            match_confidence=100,
             cert = '6908c7e0f2cc9a700ddd05efc41836da3057842a6c070cdc41251504df3735f4',
             http = 'db2f9ca747f3e2e0896a1b783b27738fddfb4ba8f0500c0bfc0ad75e8f082090',
             ip_metadata=IpMetadata(
@@ -747,7 +747,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'Control',
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = True,
@@ -773,7 +772,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'Provocative Attire',
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = True,
@@ -799,7 +797,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'Control',
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = True,
@@ -825,7 +822,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'Control',
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = True,
@@ -851,7 +847,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'E-commerce',
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = True,
@@ -877,7 +872,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'E-commerce',
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = True,
@@ -903,7 +897,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'E-commerce',
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = True,
@@ -929,7 +922,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'E-commerce',
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = True,
@@ -955,7 +947,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly = False,
         category = 'Control',
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         controls_failed = True,
@@ -1082,7 +1073,6 @@ class FlattenSatelliteTest(unittest.TestCase):
         anomaly=False,
         category='Government',
         average_confidence=66.66666666666667,
-        matches_confidence=[66.66666666666667, 66.66666666666667],
         untagged_controls=False,
         untagged_response=False,
         controls_failed=False,
@@ -1103,6 +1093,7 @@ class FlattenSatelliteTest(unittest.TestCase):
             cert='',
             http='b7e803c4b738908b8c525dd7d96a49ea96c4e532ad91a027b65ba9b520a653fb',
             matches_control='asnum asname',
+            match_confidence=66.66666666666667,
             ip_metadata=IpMetadata(
                 asn=20940,
                 as_name='AKAMAI-ASN1'
@@ -1112,6 +1103,7 @@ class FlattenSatelliteTest(unittest.TestCase):
             cert='',
             http='65a6a40c1b153b87b20b789f0dc93442e3ed172774c5dfa77c07b5146333802e',
             matches_control='asnum asname',
+            match_confidence=66.66666666666667,
             ip_metadata=IpMetadata(
                 asn=20940,
                 as_name='AKAMAI-ASN1'

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -1128,6 +1128,156 @@ class FlattenSatelliteTest(unittest.TestCase):
 
     self.assertListEqual(results, expected)
 
+  def test_flattenmeasurement_satellite_v2p2_no_match_confidence(self) -> None:
+    """Test flattening of Satellite v2.2 measurements that fail but eventually succeed."""
+    filenames = [
+        'gs://firehook-scans/satellite/CP_Satellite-2021-08-22-12-00-01/results.json',
+    ]
+
+    # yapf: disable
+    interference = [{
+        "confidence": {
+            "average": 0,
+            "matches": None,
+            "untagged_controls": False,
+            "untagged_response": False
+        },
+        "passed_liveness": False,
+        "connect_error": False,
+        "in_control_group":  True,
+        "anomaly": False,
+        "excluded": False,
+        "vp": "8.8.8.8",
+        "test_url": "zhibo8.cc",
+        "start_time": "2021-08-22 14:51:20.888764605 -0400 EDT",
+        "end_time": "2021-08-22 14:51:20.959570192 -0400 EDT",
+        "exclude_reason": [],
+        "location": {
+            "country_name": "United States",
+            "country_code": "US"
+        },
+        "response": [{
+            "url": "a.root-servers.net",
+            "has_type_a": False,
+            "response": {},
+            "error": "null",
+            "rcode": -1
+        }, {
+            "url": "zhibo8.cc",
+            "has_type_a": True,
+            "response": {
+                "101.37.178.168": {
+                    "http": "7bb5038f4572646cb72ef3ac67762b6545b421df215b7b6b2e1b29597ba5302b",
+                    "cert": "df49f4736dcaac175f585e97605e6179e188d73d85c2f1becf48e223921c19b1",
+                    "asnum": 37963,
+                    "asname": "CNNIC-ALIBABA-CN-NET-AP Hangzhou Alibaba Advertising Co.,Ltd.",
+                    "matched": None
+                }
+            },
+            "error": "null",
+            "rcode": 0
+        }, {
+            "url": "a.root-servers.net",
+            "has_type_a": False,
+            "response": {},
+            "error": "null",
+            "rcode": -1
+        }]
+    }]
+    # yapf: enable
+
+    expected = [
+        SatelliteRow(
+            domain='a.root-servers.net',
+            category='Control',
+            ip='8.8.8.8',
+            date='2021-08-22',
+            start_time='2021-08-22T14:51:20.888764605-04:00',
+            end_time='2021-08-22T14:51:20.959570192-04:00',
+            anomaly=False,
+            success=False,
+            is_control=True,
+            controls_failed=True,
+            measurement_id='ab3b0ed527334c6ba988362e6a2c98fc',
+            source='CP_Satellite-2021-08-22-12-00-01',
+            ip_metadata=IpMetadata(country='US'),
+            rcode=-1,
+            is_control_ip=True,
+            untagged_controls=False,
+            untagged_response=False,
+            excluded=False,
+            exclude_reason='',
+            received=[]),
+        SatelliteRow(
+            domain='zhibo8.cc',
+            category='Media sharing',
+            ip='8.8.8.8',
+            date='2021-08-22',
+            start_time='2021-08-22T14:51:20.888764605-04:00',
+            end_time='2021-08-22T14:51:20.959570192-04:00',
+            anomaly=False,
+            success=True,
+            is_control=False,
+            controls_failed=True,
+            measurement_id='ab3b0ed527334c6ba988362e6a2c98fc',
+            source='CP_Satellite-2021-08-22-12-00-01',
+            ip_metadata=IpMetadata(country='US',),
+            rcode=0,
+            is_control_ip=True,
+            average_confidence=0,
+            untagged_controls=False,
+            untagged_response=False,
+            excluded=False,
+            exclude_reason='',
+            has_type_a=True,
+            received=[
+                SatelliteAnswer(
+                    ip='101.37.178.168',
+                    http=
+                    '7bb5038f4572646cb72ef3ac67762b6545b421df215b7b6b2e1b29597ba5302b',
+                    cert=
+                    'df49f4736dcaac175f585e97605e6179e188d73d85c2f1becf48e223921c19b1',
+                    matches_control='',
+                    ip_metadata=IpMetadata(
+                        asn=37963,
+                        as_name=
+                        'CNNIC-ALIBABA-CN-NET-AP Hangzhou Alibaba Advertising Co.,Ltd.'
+                    ),
+                )
+            ]),
+        SatelliteRow(
+            domain='a.root-servers.net',
+            category='Control',
+            ip='8.8.8.8',
+            date='2021-08-22',
+            start_time='2021-08-22T14:51:20.888764605-04:00',
+            end_time='2021-08-22T14:51:20.959570192-04:00',
+            anomaly=False,
+            success=False,
+            is_control=True,
+            controls_failed=True,
+            measurement_id='ab3b0ed527334c6ba988362e6a2c98fc',
+            source='CP_Satellite-2021-08-22-12-00-01',
+            ip_metadata=IpMetadata(country='US'),
+            rcode=-1,
+            is_control_ip=True,
+            untagged_controls=False,
+            untagged_response=False,
+            excluded=False,
+            exclude_reason='',
+            received=[])
+    ]
+
+    flattener = get_satellite_flattener()
+    results = []
+
+    for filename, line in zip(filenames, interference):
+      rows = flattener.process_satellite(filename, line,
+                                         'ab3b0ed527334c6ba988362e6a2c98fc')
+      results.extend(list(rows))
+
+    self.assertListEqual(results, expected)
+
   def test_flattenmeasurement_blockpage(self) -> None:
     """Test parsing a blockpage measurement."""
     # yapf: disable

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -1007,7 +1007,6 @@ class SatelliteTest(unittest.TestCase):
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = False,
         average_confidence = 100,
-        matches_confidence = [100, 100],
         untagged_controls = False,
         untagged_response = False,
         excluded = False,
@@ -1019,6 +1018,7 @@ class SatelliteTest(unittest.TestCase):
             http = '0728405c8a7cfa601fc6e8a0dff71038624dd672fbbfc91605905a536ff9e1a8',
             cert = '',
             matches_control = 'ip http asnum asname',
+            match_confidence = 100,
             ip_metadata=IpMetadata(
                 asn=13335,
                 as_name='CLOUDFLARENET'
@@ -1028,6 +1028,7 @@ class SatelliteTest(unittest.TestCase):
             http = '2022c19b47cac1c5746f9d2efa5b7383f78c4bd1b4443f96e28f3a3019cc8ba0',
             cert = '',
             matches_control = 'ip http asnum asname',
+            match_confidence = 100,
             ip_metadata=IpMetadata(
                 asn=13335,
                 as_name='CLOUDFLARENET'
@@ -1054,7 +1055,6 @@ class SatelliteTest(unittest.TestCase):
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = False,
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         excluded = False,
@@ -1081,7 +1081,6 @@ class SatelliteTest(unittest.TestCase):
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = True,
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         excluded = False,
@@ -1108,7 +1107,6 @@ class SatelliteTest(unittest.TestCase):
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = True,
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         excluded = False,
@@ -1135,7 +1133,6 @@ class SatelliteTest(unittest.TestCase):
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = True,
         average_confidence = None,
-        matches_confidence = [],
         untagged_controls = False,
         untagged_response = False,
         excluded = False,
@@ -1327,19 +1324,30 @@ class SatelliteTest(unittest.TestCase):
     ]
 
     expected = [
-      (0, [0], False, True),
-      (100, [100, 100, 100, 100], False, False),
-      (62.5, [0, 50, 100, 100], False, False)
+      (0, False, True),
+      (100, False, False),
+      (62.5, False, False)
+    ]
+    expected_matches_confidence = [
+      [0],
+      [100, 100, 100, 100],
+      [0, 50, 100, 100],
     ]
     # yapf: enable
 
     result = []
+    all_matches_confidence = []
     for scan in scans:
       scan = satellite._calculate_confidence(scan, 1)
-      result.append((scan.average_confidence, scan.matches_confidence,
-                     scan.untagged_controls, scan.untagged_response))
+      result.append((scan.average_confidence, scan.untagged_controls,
+                     scan.untagged_response))
+      matches_confidence = []
+      for answer in scan.received:
+        matches_confidence.append(answer.match_confidence)
+      all_matches_confidence.append(matches_confidence)
 
     self.assertListEqual(result, expected)
+    self.assertListEqual(all_matches_confidence, expected_matches_confidence)
 
   def test_verify(self) -> None:
     """Test verification of Satellite v1 data."""
@@ -1430,7 +1438,6 @@ class SatelliteTest(unittest.TestCase):
             controls_failed=False,
             rcode=0,
             average_confidence=100,
-            matches_confidence=[100, 100],
             untagged_controls=False,
             untagged_response=False,
             excluded=False,
@@ -1442,12 +1449,14 @@ class SatelliteTest(unittest.TestCase):
                     http=
                     "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert="",
+                    match_confidence=100,
                     ip_metadata=IpMetadata(asn=13335, as_name="CLOUDFLARENET")),
                 SatelliteAnswer(
                     ip="104.31.16.118",
                     http=
                     "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert="",
+                    match_confidence=100,
                     ip_metadata=IpMetadata(asn=13335, as_name="CLOUDFLARENET"))
             ],
             ip_metadata=IpMetadata(country="US",))
@@ -1507,7 +1516,6 @@ class SatelliteTest(unittest.TestCase):
             controls_failed=False,
             rcode=0,
             average_confidence=100,
-            matches_confidence=[100, 100],
             untagged_controls=False,
             untagged_response=False,
             excluded=False,
@@ -1520,6 +1528,7 @@ class SatelliteTest(unittest.TestCase):
                     "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert="",
                     ip_metadata=IpMetadata(asn=13335, as_name="CLOUDFLARENET"),
+                    match_confidence=100,
                     http_response=HttpsResponse(
                         status='302 Moved Temporarily',
                         body=
@@ -1541,6 +1550,7 @@ class SatelliteTest(unittest.TestCase):
                     http=
                     "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert="",
+                    match_confidence=100,
                     ip_metadata=IpMetadata(asn=13335, as_name="CLOUDFLARENET"))
             ],
             ip_metadata=IpMetadata(country="US",))
@@ -1573,7 +1583,6 @@ class SatelliteTest(unittest.TestCase):
             controls_failed = False,
             rcode = 0,
             average_confidence = 100,
-            matches_confidence = [100,100],
             untagged_controls = False,
             untagged_response = False,
             excluded = False,
@@ -1585,6 +1594,7 @@ class SatelliteTest(unittest.TestCase):
                     http = "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert = "",
                     matches_control = "ip http asnum asname",
+                    match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1595,6 +1605,7 @@ class SatelliteTest(unittest.TestCase):
                     http = "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert = "",
                     matches_control = "ip http asnum asname",
+                    match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1620,7 +1631,6 @@ class SatelliteTest(unittest.TestCase):
             controls_failed = True,
             rcode = 0,
             average_confidence = 0,
-            matches_confidence = [],
             untagged_controls = False,
             untagged_response = False,
             excluded = False,
@@ -1667,7 +1677,6 @@ class SatelliteTest(unittest.TestCase):
             controls_failed = False,
             rcode = 0,
             average_confidence = 100,
-            matches_confidence = [100,100],
             untagged_controls = False,
             untagged_response = False,
             excluded = False,
@@ -1679,6 +1688,7 @@ class SatelliteTest(unittest.TestCase):
                     http = "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert = "",
                     matches_control = "ip http asnum asname",
+                    match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1689,6 +1699,7 @@ class SatelliteTest(unittest.TestCase):
                     http = "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert = "",
                     matches_control = "ip http asnum asname",
+                    match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1714,7 +1725,6 @@ class SatelliteTest(unittest.TestCase):
             controls_failed = False,
             rcode = 0,
             average_confidence = 100,
-            matches_confidence = [100,100],
             untagged_controls = False,
             untagged_response = False,
             excluded = False,
@@ -1726,6 +1736,7 @@ class SatelliteTest(unittest.TestCase):
                     http = "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert = "",
                     matches_control = "ip http asnum asname",
+                    match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1736,6 +1747,7 @@ class SatelliteTest(unittest.TestCase):
                     http = "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert = "",
                     matches_control = "ip http asnum asname",
+                    match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1761,7 +1773,6 @@ class SatelliteTest(unittest.TestCase):
             controls_failed = False,
             rcode = 0,
             average_confidence = 0,
-            matches_confidence = [0],
             untagged_controls = False,
             untagged_response = False,
             excluded = False,
@@ -1773,6 +1784,7 @@ class SatelliteTest(unittest.TestCase):
                     http = "177a8341782a57778766a7334d3e99ecb61ce54bbcc48838ddda846ea076726d",
                     cert = "",
                     matches_control = "",
+                    match_confidence = 0,
                     ip_metadata=IpMetadata(
                         asn=31483,
                         as_name="ERTELECOM-DC-AS"

--- a/pipeline/metadata/test_schema.py
+++ b/pipeline/metadata/test_schema.py
@@ -121,7 +121,6 @@ class SchemaTest(unittest.TestCase):
         source = 'CP_Satellite-2021-10-20-12-00-01',
         controls_failed = True,
         average_confidence = 100,
-        matches_confidence = [100],
         untagged_controls = False,
         untagged_response = False,
         excluded = False,
@@ -144,6 +143,7 @@ class SchemaTest(unittest.TestCase):
             cert = 'MII...',
             http = 'c5ba7f2da503045170f1d66c3e9f84576d8f3a606bb246db589a8f62c65921af',
             matches_control = 'ip http asnum asname',
+            match_confidence = 100,
             ip_metadata = schema.IpMetadata(
                 asn=16509,
                 as_name='AMAZON-02',


### PR DESCRIPTION
Another schema change from [here](https://docs.google.com/document/d/1BMohMUiqJzYnTR8fdEqb1Ang5r1oW_aEHdsxQraQPR8/edit#)

This passed the unit/e2e tests, but I'd still like to test it against a full backfill to make sure there aren't any weird cases where `scan['confidence']['matches']` has a different number of entries from the answers received.

Edit: ran a [test job](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-04-05_11_35_54-14814092259207008594?project=firehook-censoredplanet) that failed because sometimes `match_confidence` field is missing. (As in `None`, it's never partially missing) Added in some code to accommodate that case + a test. [Successful job](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-04-06_08_58_40-14929207060584480133?project=firehook-censoredplanet)