### PR TITLE
schema match test

### DIFF
--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -19,7 +19,7 @@ import datetime
 import logging
 import pathlib
 import re
-from typing import Optional, Tuple, Dict, List, Any, Iterator, Iterable, Union
+from typing import Optional, Tuple, Dict, List, Any, Iterator, Iterable
 
 import apache_beam as beam
 from apache_beam.io.gcp.gcsfilesystem import GCSFileSystem
@@ -28,7 +28,7 @@ from apache_beam.options.pipeline_options import SetupOptions
 from google.cloud import bigquery as cloud_bigquery  # type: ignore
 
 from pipeline.metadata.beam_metadata import DateIpKey, IP_METADATA_PCOLLECTION_NAME, ROWS_PCOLLECION_NAME, make_date_ip_key, merge_metadata_with_rows
-from pipeline.metadata.schema import BigqueryRow, PageFetchRow, IpMetadataWithKeys
+from pipeline.metadata.schema import BigqueryRow, IpMetadataWithKeys
 from pipeline.metadata import schema
 from pipeline.metadata import flatten_base
 from pipeline.metadata import flatten
@@ -387,14 +387,13 @@ class ScanDataBeamPipelineRunner():
       yield (metadata_key, metadata_values)
 
   def _write_to_bigquery(self, scan_type: str,
-                         rows: beam.pvalue.PCollection[Union[BigqueryRow,
-                                                             PageFetchRow]],
+                         rows: beam.pvalue.PCollection[BigqueryRow],
                          table_name: str, incremental_load: bool) -> None:
     """Write out row to a bigquery table.
 
     Args:
       scan_type: one of 'echo', 'discard', 'http', 'https',
-        'satellite' or 'page_fetch'
+        or 'satellite'
       rows: PCollection[BigqueryRow] of data to write.
       table_name: dataset.table name like 'base.echo_scan' Determines which
         tables to write to.

--- a/pipeline/metadata/test_schema.py
+++ b/pipeline/metadata/test_schema.py
@@ -1,13 +1,14 @@
 """Unit tests for the schema pipeline."""
 
 import unittest
+from typing import Dict, Any
 
 from apache_beam.io.gcp.internal.clients import bigquery as beam_bigquery
 
 from pipeline.metadata import schema
 
 
-class PipelineMainTest(unittest.TestCase):
+class SchemaTest(unittest.TestCase):
   """Unit tests for schema."""
 
   def test_get_bigquery_schema_hyperquack(self) -> None:
@@ -49,3 +50,197 @@ class PipelineMainTest(unittest.TestCase):
     expected_table_schema.fields.append(expected_field_schema_2)
 
     self.assertEqual(table_schema, expected_table_schema)
+
+  def test_hyperquack_flatten_matches_bq_schema(self) -> None:
+    """Test that the hyperquack flat row schema matches the bq schema."""
+    bq_table_schema = schema.get_beam_bigquery_schema(
+        schema.get_bigquery_schema('https'))
+
+    # yapf: disable
+    row = schema.HyperquackRow(
+        domain = 'www.arabhra.org',
+        category = 'Intergovernmental Organizations',
+        ip = '213.175.166.157',
+        date = '2020-11-06',
+        start_time = '2020-11-06T15:24:21.124508839-05:00',
+        end_time = '2020-11-06T15:24:21.812075476-05:00',
+        error = 'Incorrect web response: status lines don\'t match',
+        anomaly = False,
+        success = False,
+        is_control = False,
+        controls_failed = False,
+        measurement_id = '81e2a76dafe04131bc38fc6ec7bbddca',
+        source = 'CP_Quack-https-2020-11-06-15-15-31',
+        stateful_block = False,
+        ip_metadata = schema.IpMetadata(
+            netblock = '213.175.166.157/24',
+            asn = 13335,
+            as_name = 'CLOUDFLARENET',
+            as_full_name = 'Cloudflare Inc.',
+            as_class = 'Content',
+            country = 'US',
+            organization = 'Fake Organization'
+        ),
+        received = schema.HttpsResponse(
+            is_known_blockpage = False,
+            page_signature = 'x_example_signature',
+            status = '302 Found',
+            body = 'example body',
+            headers = [
+                'Content-Language: en',
+                'X-Frame-Options: SAMEORIGIN',
+            ],
+            tls_version = 771,
+            tls_cipher_suite = 49199,
+            tls_cert = 'MIIH...'
+        )
+    )
+    # yapf: disable
+    flat_row = schema.flatten_for_bigquery(row)
+
+    self.assert_flat_row_matches_bq_schema(flat_row, bq_table_schema)
+
+  def test_satellite_flatten_matches_bq_schema(self) -> None:
+    """Test that the satellite flat row schema matches the bq schema."""
+    bq_table_schema = schema.get_beam_bigquery_schema(schema.get_bigquery_schema('satellite'))
+
+    # yapf: disable
+    row = schema.SatelliteRow(
+        domain = 'a.root-servers.net',
+        is_control =  True,
+        category = 'Control',
+        ip = '62.80.182.26',
+        is_control_ip = False,
+        date = '2021-10-20',
+        start_time = '2021-10-20T14:51:45.361175691-04:00',
+        end_time = '2021-10-20T14:51:46.261234037-04:00',
+        error = 'read udp 141.212.123.185:30437->62.80.182.26:53: read: connection refused',
+        anomaly = False,
+        success = False,
+        measurement_id = '47de079652ca53f7bdb57ca956e1c70e',
+        source = 'CP_Satellite-2021-10-20-12-00-01',
+        controls_failed = True,
+        average_confidence = 100,
+        matches_confidence = [100],
+        untagged_controls = False,
+        untagged_response = False,
+        excluded = False,
+        exclude_reason = '',
+        rcode = -1,
+        has_type_a = True,
+        ip_metadata = schema.IpMetadata(
+          country = 'UA',
+          name = 'mx4.orlantrans.com.',
+          netblock = '213.175.166.157/24',
+          asn = 13335,
+          as_name = 'CLOUDFLARENET',
+          as_full_name = 'Cloudflare Inc.',
+          as_class = 'Content',
+          organization = 'Fake Organization'
+        ),
+        received = [
+          schema.SatelliteAnswer(
+            ip = '13.249.134.38',
+            cert = 'MII...',
+            http = 'c5ba7f2da503045170f1d66c3e9f84576d8f3a606bb246db589a8f62c65921af',
+            matches_control = 'ip http asnum asname',
+            ip_metadata = schema.IpMetadata(
+                asn=16509,
+                as_name='AMAZON-02',
+                country = 'US',
+                netblock = '213.175.166.157/24',
+            ),
+            http_error = 'Get \"http://31.13.77.33:80/\": dial tcp 31.13.77.33:80: connect: connection refused',
+            http_response = schema.HttpsResponse(
+              is_known_blockpage = False,
+              page_signature = 'x_example_fp',
+              status = '200',
+              body = 'example body',
+              tls_version = 123,
+              tls_cipher_suite = 3,
+              tls_cert = 'MII...',
+              headers = [
+                'Content-Language: en',
+                'X-Frame-Options: SAMEORIGIN',
+              ]
+            ),
+            https_error = 'Get \"https://31.13.77.33:443/\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)',
+            https_response = schema.HttpsResponse(
+              is_known_blockpage = False,
+              page_signature = 'x_example_fp',
+              status = '200',
+              body = 'example body',
+              tls_version = 123,
+              tls_cipher_suite = 3,
+              tls_cert = 'MII...',
+              headers = [
+                'Content-Language: en',
+                'X-Frame-Options: SAMEORIGIN',
+              ]
+            )
+          )
+        ]
+    )
+    # yapf: disable
+    flat_row = schema.flatten_for_bigquery(row)
+
+    self.assert_flat_row_matches_bq_schema(flat_row, bq_table_schema)
+
+
+  def assert_flat_row_matches_bq_schema(self, flat_row: Dict[str, Any],
+           bq_schema: beam_bigquery.TableSchema) -> None:
+    """Helper for testing schema matches
+
+    Raises:
+      Exception if types don't match or the value is incompletly filled in.
+    """
+    schema_names = [field.name for field in bq_schema.fields]
+
+    for (key, value) in flat_row.items():
+      self.assertIn(key, schema_names)
+      i = schema_names.index(key)
+      bq_field = bq_schema.fields[i]
+      self.assert_compatible_bq_field_type(bq_field, value, key)
+
+  # pylint: disable=multiple-statements
+  # pylint: disable=too-many-return-statements
+  # pylint: disable=too-many-branches
+  def assert_compatible_bq_field_type(self, field: beam_bigquery.TableFieldSchema, value: Any, field_name: str) -> None:
+    """Helper for testing bq row type matches.
+
+    Some kinds of type coercion are allowed in bq writes.
+    This doesn't aim to be comprehensive,
+    just a sanity check for the fields we have.
+
+    Raises:
+      Exception if types don't match or the value is incompletly filled in.
+    """
+    value_type = type(value)
+    field_type = field.type
+
+    if value is None:
+      raise Exception(f'Please enumerate all row fields in the test. Missing field: {field_name}')
+    if isinstance(value, str):
+      if field_type == 'string': return None
+      if field_type == 'date': return None
+      if field_type == 'timestamp': return None
+      raise Exception(f'Row value type {value_type} doesn\'t match {field_type}')
+    if isinstance(value, bool):
+      if field_type == 'boolean': return None
+      raise Exception(f'Row value type {value_type} doesn\'t match {field_type}')
+    if isinstance(value, float):
+      if field_type == 'float': return None
+      raise Exception(f'Row value type {value_type} doesn\'t match {field_type}')
+    if isinstance(value, int):
+      if field_type == 'integer': return None
+      if field_type == 'float': return None
+      raise Exception(f'Row value type {value_type} doesn\'t match {field_type}')
+    if isinstance(value, list):
+      if len(value) == 0:
+        raise Exception(f'Please add content to lists in the test. Empty list: {field_name}')
+      if not field.mode == 'repeated':
+        raise Exception(f'List {value} in non repeated field: {field_name}')
+      return self.assert_compatible_bq_field_type(field, value[0], field_name)
+    if isinstance(value, dict):
+      return self.assert_flat_row_matches_bq_schema(value, field)
+    raise Exception(f'Unknown row value type {value_type}, value: {value}')


### PR DESCRIPTION
Splitting out the internal representation of the data from the final serialized representation in https://github.com/censoredplanet/censoredplanet-analysis/pull/133 means that it's now possible to miss some boilerplate and introduce mismatches between the schema names or types (I've already done this twice in just two weeks).

The e2e tests can catch these kinds of problems since they're actually writing to bigquery, but they don't always enumerate every corner of the data format and they're slow. This PR adds some unit tests comparing the flattened rows we're planning to write to bigquery with intended schemas so we can catch problems earlier.

This isn't aiming to be a fully verified check that the bq write will work (that's what the e2e tests are for.) Bigquery's rules about how writing and type coercion work are actually very complex and can only be fully verified by just writing to bq. This is also majorly violating the "simplicity/no logic" principle of unit testing. But it's intended as a sanity check for the format so I can stop shooting myself in the foot.

Also remove the blockpage bq schema that we're not writing anymore.