### PR TITLE
Make matches_control a struct

### DIFF
--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -116,12 +116,17 @@ def _make_matches_control(tags: List[str]) -> MatchesControl:
   Returns:
     string like "ip http cert"
   """
-  matches_control = MatchesControl(
-      ip='ip' in tags,
-      http='http' in tags,
-      cert='cert' in tags,
-      asnum='asnum' in tags,
-      asname='asname' in tags)
+  matches_control = MatchesControl()
+  if 'ip' in tags:
+    matches_control.ip = True
+  if 'http' in tags:
+    matches_control.http = True
+  if 'cert' in tags:
+    matches_control.cert = True
+  if 'asnum' in tags:
+    matches_control.asnum = True
+  if 'asname' in tags:
+    matches_control.asname = True
   return matches_control
 
 

--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -13,7 +13,7 @@ from typing import Optional, Dict, Any, Iterator, List, Tuple
 import apache_beam as beam
 
 from pipeline.metadata import flatten_base
-from pipeline.metadata.schema import SatelliteRow, PageFetchRow, SatelliteAnswer, IpMetadata
+from pipeline.metadata.schema import SatelliteRow, PageFetchRow, SatelliteAnswer, IpMetadata, MatchesControl
 from pipeline.metadata.blockpage import BlockpageMatcher
 from pipeline.metadata.domain_categories import DomainCategoryMatcher
 
@@ -23,7 +23,6 @@ ResponsesEntry = Any
 # https://docs.censoredplanet.org/dns.html#id1
 BlockpageEntry = Any
 
-SATELLITE_TAGS = {'ip', 'http', 'asnum', 'asname', 'cert'}
 SATELLITE_V2_1_START_DATE = datetime.date(2021, 3, 1)
 SATELLITE_V2_2_START_DATE = datetime.date(2021, 6, 24)
 
@@ -101,14 +100,14 @@ def _annotate_received_ips_v1(
   for (ip, tags) in received_ips.items():
     received_answer = SatelliteAnswer(ip)
     if tags and len(tags) != 0:
-      received_answer.matches_control = _append_tags(tags)
+      received_answer.matches_control = _make_matches_control(tags)
     all_received.append(received_answer)
   base_response.received = all_received
 
   yield base_response
 
 
-def _append_tags(tags: List[str]) -> str:
+def _make_matches_control(tags: List[str]) -> MatchesControl:
   """Return valid received ip tags as a string
 
   Args:
@@ -117,7 +116,13 @@ def _append_tags(tags: List[str]) -> str:
   Returns:
     string like "ip http cert"
   """
-  return ' '.join([tag for tag in tags if tag in SATELLITE_TAGS])
+  matches_control = MatchesControl(
+      ip='ip' in tags,
+      http='http' in tags,
+      cert='cert' in tags,
+      asnum='asnum' in tags,
+      asname='asname' in tags)
+  return matches_control
 
 
 def split_rcodes(rcodes: List[str]) -> Tuple[List[int], List[int]]:
@@ -194,7 +199,7 @@ def _process_satellite_v2p1(base_response: SatelliteRow,
     for (ip, tags) in input_response_data.items():
       received = SatelliteAnswer(ip)
       if tags:
-        received.matches_control = _append_tags(tags)
+        received.matches_control = _make_matches_control(tags)
       all_received.append(received)
 
     success_observation = deepcopy(base_response)
@@ -407,7 +412,6 @@ class SatelliteFlattener():
               ip=ip,
               http=answer.get('http'),
               cert=answer.get('cert'),
-              matches_control='',
               match_confidence=match_confidence,
               ip_metadata=IpMetadata(
                   as_name=answer.get('asname'),
@@ -415,7 +419,7 @@ class SatelliteFlattener():
               ))
           matched = answer.get('matched', [])
           if matched:
-            received.matches_control = _append_tags(matched)
+            received.matches_control = _make_matches_control(matched)
           all_received.append(received)
         roundtrip_row.received = all_received
         yield roundtrip_row

--- a/pipeline/metadata/schema.py
+++ b/pipeline/metadata/schema.py
@@ -85,11 +85,11 @@ def merge_ip_metadata(base: IpMetadata, new: IpMetadata) -> None:
 @dataclass
 class MatchesControl():
   """Class to keep track of which answer fields matched the control."""
-  ip: bool = False
-  http: bool = False
-  cert: bool = False
-  asnum: bool = False
-  asname: bool = False
+  ip: Optional[bool] = None
+  http: Optional[bool] = None
+  cert: Optional[bool] = None
+  asnum: Optional[bool] = None
+  asname: Optional[bool] = None
 
 
 @dataclass

--- a/pipeline/metadata/schema.py
+++ b/pipeline/metadata/schema.py
@@ -403,17 +403,13 @@ SATELLITE_BIGQUERY_SCHEMA = _add_schemas(
                 'asname': ('string', 'nullable'),
                 'http': ('string', 'nullable'),
                 'cert': ('string', 'nullable'),
-                'matches_control': (
-                  'record',
-                  'nullable',
-                  {
+                'matches_control': ('record', 'nullable', {
                     'ip': ('boolean', 'nullable'),
                     'http': ('boolean', 'nullable'),
                     'cert': ('boolean', 'nullable'),
                     'asnum': ('boolean', 'nullable'),
                     'asname': ('boolean', 'nullable'),
-                  }
-                ),
+                }),
                 'match_confidence': ('float', 'nullable'),
                 # HTTP
                 'http_error': ('string', 'nullable'),
@@ -480,8 +476,9 @@ def get_beam_bigquery_schema(
   table_schema.fields = table_fields
   return table_schema
 
-  
-def _get_beam_bigquery_schema_list(fields: Dict[str, Any]) -> List[beam_bigquery.TableFieldSchema]:
+
+def _get_beam_bigquery_schema_list(
+    fields: Dict[str, Any]) -> List[beam_bigquery.TableFieldSchema]:
   """A helper method for get_beam_bigquery_schema which returns a list of fields."""
   field_list: List[beam_bigquery.TableFieldSchema] = []
 
@@ -496,8 +493,10 @@ def _get_beam_bigquery_schema_list(fields: Dict[str, Any]) -> List[beam_bigquery
 
     if field_type == 'record':
       substruct: Dict[str, Any] = attributes[2]
-      subfields: List[beam_bigquery.TableFieldSchema] = _get_beam_bigquery_schema_list(substruct)
+      subfields: List[
+          beam_bigquery.TableFieldSchema] = _get_beam_bigquery_schema_list(
+              substruct)
       field_schema.fields = subfields
-    
+
     field_list.append(field_schema)
   return field_list

--- a/pipeline/metadata/test_flatten.py
+++ b/pipeline/metadata/test_flatten.py
@@ -3,7 +3,7 @@
 import unittest
 
 from pipeline.metadata import flatten
-from pipeline.metadata.schema import HyperquackRow, SatelliteRow, SatelliteAnswer
+from pipeline.metadata.schema import HyperquackRow, SatelliteRow, SatelliteAnswer, MatchesControl
 
 
 class FlattenMeasurementTest(unittest.TestCase):
@@ -98,7 +98,14 @@ class FlattenMeasurementTest(unittest.TestCase):
         success=True,
         received=[
             SatelliteAnswer(
-                ip='151.101.1.184', matches_control='ip http cert asnum asname')
+                ip='151.101.1.184',
+                matches_control=MatchesControl(
+                    ip=True,
+                    http=True,
+                    cert=True,
+                    asnum=True,
+                    asname=True,
+                ))
         ],
         rcode=0,
         measurement_id='87a324f6c03150dda81c93bdeddb4adf',

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -3,7 +3,7 @@
 import json
 import unittest
 
-from pipeline.metadata.schema import SatelliteRow, SatelliteAnswer, PageFetchRow, IpMetadata, HttpsResponse
+from pipeline.metadata.schema import SatelliteRow, SatelliteAnswer, PageFetchRow, IpMetadata, HttpsResponse, MatchesControl
 from pipeline.metadata.blockpage import BlockpageMatcher
 from pipeline.metadata.domain_categories import DomainCategoryMatcher
 
@@ -83,15 +83,40 @@ class FlattenSatelliteTest(unittest.TestCase):
             received=[
                 SatelliteAnswer(
                     ip='151.101.1.184',
-                    matches_control='ip http cert asnum asname'),
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=True,
+                        asnum=True,
+                        asname=True,
+                    )),
                 SatelliteAnswer(
                     ip='151.101.129.184',
-                    matches_control='ip http cert asnum asname'),
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=True,
+                        asnum=True,
+                        asname=True,
+                    )),
                 SatelliteAnswer(
                     ip='151.101.193.184',
-                    matches_control='ip http cert asnum asname'),
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=True,
+                        asnum=True,
+                        asname=True,
+                    )),
                 SatelliteAnswer(
-                    ip='151.101.65.184', matches_control='ip cert asnum asname')
+                    ip='151.101.65.184',
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=False,
+                        cert=True,
+                        asnum=True,
+                        asname=True,
+                    ))
             ],
             rcode=0,
             measurement_id='ab3b0ed527334c6ba988362e6a2c98fc',
@@ -371,7 +396,13 @@ class FlattenSatelliteTest(unittest.TestCase):
             received=[
                 SatelliteAnswer(
                     ip='88.212.202.9',
-                    matches_control='ip http cert asnum asname',
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=True,
+                        asnum=True,
+                        asname=True,
+                    ),
                     match_confidence=100,
                     http=
                     '8351c0267c2cd7866ff04c04261f06cd75af9a7130aac848ca43fd047404e229',
@@ -728,7 +759,13 @@ class FlattenSatelliteTest(unittest.TestCase):
         rcode = 0,
         received = [SatelliteAnswer(
             ip = '113.217.247.90',
-            matches_control = 'ip http cert asnum asname',
+            matches_control=MatchesControl(
+                ip=True,
+                http=True,
+                cert=True,
+                asnum=True,
+                asname=True,
+            ),
             match_confidence=100,
             cert = '6908c7e0f2cc9a700ddd05efc41836da3057842a6c070cdc41251504df3735f4',
             http = 'db2f9ca747f3e2e0896a1b783b27738fddfb4ba8f0500c0bfc0ad75e8f082090',
@@ -1092,7 +1129,13 @@ class FlattenSatelliteTest(unittest.TestCase):
             ip='92.123.189.40',
             cert='',
             http='b7e803c4b738908b8c525dd7d96a49ea96c4e532ad91a027b65ba9b520a653fb',
-            matches_control='asnum asname',
+            matches_control=MatchesControl(
+                ip=False,
+                http=False,
+                cert=False,
+                asnum=True,
+                asname=True,
+            ),
             match_confidence=66.66666666666667,
             ip_metadata=IpMetadata(
                 asn=20940,
@@ -1102,7 +1145,13 @@ class FlattenSatelliteTest(unittest.TestCase):
             ip='92.123.189.41',
             cert='',
             http='65a6a40c1b153b87b20b789f0dc93442e3ed172774c5dfa77c07b5146333802e',
-            matches_control='asnum asname',
+            matches_control=MatchesControl(
+                ip=False,
+                http=False,
+                cert=False,
+                asnum=True,
+                asname=True,
+            ),
             match_confidence=66.66666666666667,
             ip_metadata=IpMetadata(
                 asn=20940,
@@ -1237,7 +1286,6 @@ class FlattenSatelliteTest(unittest.TestCase):
                     '7bb5038f4572646cb72ef3ac67762b6545b421df215b7b6b2e1b29597ba5302b',
                     cert=
                     'df49f4736dcaac175f585e97605e6179e188d73d85c2f1becf48e223921c19b1',
-                    matches_control='',
                     ip_metadata=IpMetadata(
                         asn=37963,
                         as_name=

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -112,7 +112,6 @@ class FlattenSatelliteTest(unittest.TestCase):
                     ip='151.101.65.184',
                     matches_control=MatchesControl(
                         ip=True,
-                        http=False,
                         cert=True,
                         asnum=True,
                         asname=True,
@@ -1130,9 +1129,6 @@ class FlattenSatelliteTest(unittest.TestCase):
             cert='',
             http='b7e803c4b738908b8c525dd7d96a49ea96c4e532ad91a027b65ba9b520a653fb',
             matches_control=MatchesControl(
-                ip=False,
-                http=False,
-                cert=False,
                 asnum=True,
                 asname=True,
             ),
@@ -1146,9 +1142,6 @@ class FlattenSatelliteTest(unittest.TestCase):
             cert='',
             http='65a6a40c1b153b87b20b789f0dc93442e3ed172774c5dfa77c07b5146333802e',
             matches_control=MatchesControl(
-                ip=False,
-                http=False,
-                cert=False,
                 asnum=True,
                 asname=True,
             ),

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -7,7 +7,7 @@ import apache_beam as beam
 from apache_beam.testing.test_pipeline import TestPipeline
 import apache_beam.testing.util as beam_test_util
 
-from pipeline.metadata.schema import SatelliteRow, PageFetchRow, HttpsResponse, SatelliteAnswer, SatelliteAnswerWithKeys, IpMetadataWithKeys, IpMetadata
+from pipeline.metadata.schema import SatelliteRow, PageFetchRow, HttpsResponse, SatelliteAnswer, SatelliteAnswerWithKeys, IpMetadataWithKeys, IpMetadata, MatchesControl
 from pipeline.metadata import satellite
 
 # pylint: disable=too-many-lines
@@ -206,7 +206,13 @@ class SatelliteTest(unittest.TestCase):
             ip = '13.249.134.38',
             cert = None,
             http = 'c5ba7f2da503045170f1d66c3e9f84576d8f3a606bb246db589a8f62c65921af',
-            matches_control = 'ip http asnum asname',
+            matches_control=MatchesControl(
+                ip=True,
+                http=True,
+                cert=False,
+                asnum=True,
+                asname=True,
+            ),
             ip_metadata=IpMetadata(
                 asn=16509,
                 as_name='AMAZON-02'
@@ -215,7 +221,13 @@ class SatelliteTest(unittest.TestCase):
             ip = '13.249.134.44',
             cert = None,
             http = '256e35b8bace0e9fe95f308deb35f82117cd7317f90a08f181516c31abe95b71',
-            matches_control = 'ip http asnum asname',
+            matches_control=MatchesControl(
+                ip=True,
+                http=True,
+                cert=False,
+                asnum=True,
+                asname=True,
+            ),
             ip_metadata=IpMetadata(
                 asn=16509,
                 as_name='AMAZON-02'
@@ -224,7 +236,13 @@ class SatelliteTest(unittest.TestCase):
             ip = '13.249.134.74',
             cert = None,
             http = '2054d0fd3887e0ded023879770d6cde57633b7881f609f1042d90fedf41685fe',
-            matches_control = 'ip http asnum asname',
+            matches_control=MatchesControl(
+                ip=True,
+                http=True,
+                cert=False,
+                asnum=True,
+                asname=True,
+            ),
             ip_metadata=IpMetadata(
                 asn=16509,
                 as_name='AMAZON-02'
@@ -233,7 +251,13 @@ class SatelliteTest(unittest.TestCase):
             ip = '13.249.134.89',
             cert = None,
             http = '0509322329cdae79475531a019a3628aa52598caa0135c5534905f0c4b4f1bac',
-            matches_control = 'ip http asnum asname',
+            matches_control=MatchesControl(
+                ip=True,
+                http=True,
+                cert=False,
+                asnum=True,
+                asname=True,
+            ),
             ip_metadata=IpMetadata(
                 asn=16509,
                 as_name='AMAZON-02'
@@ -259,7 +283,13 @@ class SatelliteTest(unittest.TestCase):
         rcode = 0,
         received = [SatelliteAnswer(
             ip = '192.124.249.107',
-            matches_control = 'ip'
+            matches_control=MatchesControl(
+                ip=True,
+                http=False,
+                cert=False,
+                asnum=False,
+                asname=False,
+            ),
         )],
         date = '2020-09-02',
         source = 'CP_Satellite-2020-09-02-12-00-01',
@@ -454,14 +484,26 @@ class SatelliteTest(unittest.TestCase):
             ip = '198.35.26.96',
             cert = '9eb21a74a3cf1ecaaf6b19253025b4ca38f182e9f1f3e7355ba3c3004d4b7a10',
             http = '7b4b4d1bfb0a645c990f55557202f88be48e1eee0c10bdcc621c7b682bf7d2ca',
-            matches_control = 'cert asnum asname',
+            matches_control=MatchesControl(
+                ip=False,
+                http=False,
+                cert=True,
+                asnum=True,
+                asname=True,
+            ),
             ip_metadata=IpMetadata(
                 asn=14907,
                 as_name='WIKIMEDIA'
             )
         ), SatelliteAnswer(
             ip = '198.35.26.86',
-            matches_control = 'cert asnum asname'
+            matches_control=MatchesControl(
+                ip=False,
+                http=False,
+                cert=True,
+                asnum=True,
+                asname=True,
+            )
         )],
         rcode = 0,
         date = '2021-03-01',
@@ -506,7 +548,13 @@ class SatelliteTest(unittest.TestCase):
         controls_failed = False,
         received = [SatelliteAnswer(
             ip = '15.126.193.233',
-            matches_control = ''
+            matches_control=MatchesControl(
+                ip=False,
+                http=False,
+                cert=False,
+                asnum=False,
+                asname=False,
+            )
         )],
         rcode = 0,
         date = '2021-03-01',
@@ -1017,7 +1065,13 @@ class SatelliteTest(unittest.TestCase):
             ip = '104.31.16.11',
             http = '0728405c8a7cfa601fc6e8a0dff71038624dd672fbbfc91605905a536ff9e1a8',
             cert = '',
-            matches_control = 'ip http asnum asname',
+            matches_control=MatchesControl(
+                ip=True,
+                http=True,
+                cert=False,
+                asnum=True,
+                asname=True,
+            ),
             match_confidence = 100,
             ip_metadata=IpMetadata(
                 asn=13335,
@@ -1027,7 +1081,13 @@ class SatelliteTest(unittest.TestCase):
             ip = '104.31.16.118',
             http = '2022c19b47cac1c5746f9d2efa5b7383f78c4bd1b4443f96e28f3a3019cc8ba0',
             cert = '',
-            matches_control = 'ip http asnum asname',
+            matches_control=MatchesControl(
+                ip=True,
+                http=True,
+                cert=False,
+                asnum=True,
+                asname=True,
+            ),
             match_confidence = 100,
             ip_metadata=IpMetadata(
                 asn=13335,
@@ -1212,7 +1272,13 @@ class SatelliteTest(unittest.TestCase):
         success = True,
         received = [SatelliteAnswer(
             ip = '104.20.161.134',
-            matches_control = ''
+            matches_control=MatchesControl(
+                ip=False,
+                http=False,
+                cert=False,
+                asnum=False,
+                asname=False,
+            ),
         )],
         date = '2020-09-02',
         ip_metadata = IpMetadata(
@@ -1231,7 +1297,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.38',
                 cert = None,
                 http = 'c5ba7f2da503045170f1d66c3e9f84576d8f3a606bb246db589a8f62c65921af',
-                matches_control = 'ip http asnum asname',
+                matches_control=MatchesControl(
+                    ip=True,
+                    http=True,
+                    cert=False,
+                    asnum=True,
+                    asname=True,
+                ),
                 ip_metadata=IpMetadata(
                     asn=16509,
                     as_name='AMAZON-02'
@@ -1240,7 +1312,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.44',
                 cert = None,
                 http = '256e35b8bace0e9fe95f308deb35f82117cd7317f90a08f181516c31abe95b71',
-                matches_control = 'ip http asnum asname',
+                matches_control=MatchesControl(
+                    ip=True,
+                    http=True,
+                    cert=False,
+                    asnum=True,
+                    asname=True,
+                ),
                 ip_metadata=IpMetadata(
                     asn=16509,
                     as_name='AMAZON-02'
@@ -1249,7 +1327,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.74',
                 cert = None,
                 http = '2054d0fd3887e0ded023879770d6cde57633b7881f609f1042d90fedf41685fe',
-                matches_control = 'ip http asnum asname',
+                matches_control=MatchesControl(
+                    ip=True,
+                    http=True,
+                    cert=False,
+                    asnum=True,
+                    asname=True,
+                ),
                 ip_metadata=IpMetadata(
                     asn=16509,
                     as_name='AMAZON-02'
@@ -1258,7 +1342,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.89',
                 cert = None,
                 http = '0509322329cdae79475531a019a3628aa52598caa0135c5534905f0c4b4f1bac',
-                matches_control = 'ip http asnum asname',
+                matches_control=MatchesControl(
+                    ip=True,
+                    http=True,
+                    cert=False,
+                    asnum=True,
+                    asname=True,
+                ),
                 ip_metadata=IpMetadata(
                     asn=16509,
                     as_name='AMAZON-02'
@@ -1281,7 +1371,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.38',
                 cert = None,
                 http = 'c5ba7f2da503045170f1d66c3e9f84576d8f3a606bb246db589a8f62c65921af',
-                matches_control = '',
+                matches_control=MatchesControl(
+                    ip=False,
+                    http=False,
+                    cert=False,
+                    asnum=False,
+                    asname=False,
+                ),
                 ip_metadata=IpMetadata(
                     asn=11111,
                     as_name='AS1'
@@ -1290,7 +1386,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.44',
                 cert = 'cert',
                 http = '256e35b8bace0e9fe95f308deb35f82117cd7317f90a08f181516c31abe95b71',
-                matches_control = 'asnum asname',
+                matches_control=MatchesControl(
+                    ip=False,
+                    http=False,
+                    cert=False,
+                    asnum=True,
+                    asname=True,
+                ),
                 ip_metadata=IpMetadata(
                     asn=22222,
                     as_name='AS2'
@@ -1299,7 +1401,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.74',
                 cert = None,
                 http = '2054d0fd3887e0ded023879770d6cde57633b7881f609f1042d90fedf41685fe',
-                matches_control = 'ip http asnum asname',
+                matches_control=MatchesControl(
+                    ip=True,
+                    http=True,
+                    cert=False,
+                    asnum=True,
+                    asname=True,
+                ),
                 ip_metadata=IpMetadata(
                     asn=22222,
                     as_name='AS2'
@@ -1308,7 +1416,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.89',
                 cert = None,
                 http = '0509322329cdae79475531a019a3628aa52598caa0135c5534905f0c4b4f1bac',
-                matches_control = 'ip http asnum asname',
+                matches_control=MatchesControl(
+                    ip=True,
+                    http=True,
+                    cert=False,
+                    asnum=True,
+                    asname=True,
+                ),
                 ip_metadata=IpMetadata(
                     asn=22222,
                     as_name='AS2'
@@ -1362,7 +1476,13 @@ class SatelliteTest(unittest.TestCase):
         success = True,
         received = [SatelliteAnswer(
             ip = '104.20.161.134',
-            matches_control = ''
+            matches_control=MatchesControl(
+                ip=False,
+                http=False,
+                cert=False,
+                asnum=False,
+                asname=False,
+            ),
         )],
         date = '2020-09-02',
         ip_metadata = IpMetadata(
@@ -1381,7 +1501,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.38',
                 cert = None,
                 http = 'c5ba7f2da503045170f1d66c3e9f84576d8f3a606bb246db589a8f62c65921af',
-                matches_control = '',
+                matches_control=MatchesControl(
+                    ip=False,
+                    http=False,
+                    cert=False,
+                    asnum=False,
+                    asname=False,
+                ),
                 ip_metadata=IpMetadata(
                     asn=16509,
                     as_name='AMAZON-02'
@@ -1390,7 +1516,13 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.44',
                 cert = None,
                 http = '256e35b8bace0e9fe95f308deb35f82117cd7317f90a08f181516c31abe95b71',
-                matches_control = '',
+                matches_control=MatchesControl(
+                    ip=False,
+                    http=False,
+                    cert=False,
+                    asnum=False,
+                    asname=False,
+                ),
                 ip_metadata=IpMetadata(
                     asn=16509,
                     as_name='AMAZON-02'
@@ -1593,7 +1725,13 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.11",
                     http = "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert = "",
-                    matches_control = "ip http asnum asname",
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=False,
+                        asnum=True,
+                        asname=True,
+                    ),
                     match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
@@ -1604,7 +1742,13 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.118",
                     http = "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert = "",
-                    matches_control = "ip http asnum asname",
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=False,
+                        asnum=True,
+                        asname=True,
+                    ),
                     match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
@@ -1641,7 +1785,13 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.11",
                     http = "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert = "",
-                    matches_control = "",
+                    matches_control=MatchesControl(
+                        ip=False,
+                        http=False,
+                        cert=False,
+                        asnum=False,
+                        asname=False,
+                    ),
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1651,7 +1801,13 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.118",
                     http = "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert = "",
-                    matches_control = "",
+                    matches_control=MatchesControl(
+                        ip=False,
+                        http=False,
+                        cert=False,
+                        asnum=False,
+                        asname=False,
+                    ),
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1687,7 +1843,13 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.11",
                     http = "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert = "",
-                    matches_control = "ip http asnum asname",
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=False,
+                        asnum=True,
+                        asname=True,
+                    ),
                     match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
@@ -1698,7 +1860,13 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.118",
                     http = "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert = "",
-                    matches_control = "ip http asnum asname",
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=False,
+                        asnum=True,
+                        asname=True,
+                    ),
                     match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
@@ -1735,7 +1903,13 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.11",
                     http = "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert = "",
-                    matches_control = "ip http asnum asname",
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=False,
+                        asnum=True,
+                        asname=True,
+                    ),
                     match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
@@ -1746,7 +1920,13 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.118",
                     http = "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert = "",
-                    matches_control = "ip http asnum asname",
+                    matches_control=MatchesControl(
+                        ip=True,
+                        http=True,
+                        cert=False,
+                        asnum=True,
+                        asname=True,
+                    ),
                     match_confidence = 100,
                     ip_metadata=IpMetadata(
                         asn=13335,
@@ -1783,7 +1963,13 @@ class SatelliteTest(unittest.TestCase):
                     ip = "188.186.157.49",
                     http = "177a8341782a57778766a7334d3e99ecb61ce54bbcc48838ddda846ea076726d",
                     cert = "",
-                    matches_control = "",
+                    matches_control=MatchesControl(
+                        ip=False,
+                        http=False,
+                        cert=False,
+                        asnum=False,
+                        asname=False,
+                    ),
                     match_confidence = 0,
                     ip_metadata=IpMetadata(
                         asn=31483,

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -209,7 +209,6 @@ class SatelliteTest(unittest.TestCase):
             matches_control=MatchesControl(
                 ip=True,
                 http=True,
-                cert=False,
                 asnum=True,
                 asname=True,
             ),
@@ -224,7 +223,6 @@ class SatelliteTest(unittest.TestCase):
             matches_control=MatchesControl(
                 ip=True,
                 http=True,
-                cert=False,
                 asnum=True,
                 asname=True,
             ),
@@ -239,7 +237,6 @@ class SatelliteTest(unittest.TestCase):
             matches_control=MatchesControl(
                 ip=True,
                 http=True,
-                cert=False,
                 asnum=True,
                 asname=True,
             ),
@@ -254,7 +251,6 @@ class SatelliteTest(unittest.TestCase):
             matches_control=MatchesControl(
                 ip=True,
                 http=True,
-                cert=False,
                 asnum=True,
                 asname=True,
             ),
@@ -285,10 +281,6 @@ class SatelliteTest(unittest.TestCase):
             ip = '192.124.249.107',
             matches_control=MatchesControl(
                 ip=True,
-                http=False,
-                cert=False,
-                asnum=False,
-                asname=False,
             ),
         )],
         date = '2020-09-02',
@@ -485,8 +477,6 @@ class SatelliteTest(unittest.TestCase):
             cert = '9eb21a74a3cf1ecaaf6b19253025b4ca38f182e9f1f3e7355ba3c3004d4b7a10',
             http = '7b4b4d1bfb0a645c990f55557202f88be48e1eee0c10bdcc621c7b682bf7d2ca',
             matches_control=MatchesControl(
-                ip=False,
-                http=False,
                 cert=True,
                 asnum=True,
                 asname=True,
@@ -498,8 +488,6 @@ class SatelliteTest(unittest.TestCase):
         ), SatelliteAnswer(
             ip = '198.35.26.86',
             matches_control=MatchesControl(
-                ip=False,
-                http=False,
                 cert=True,
                 asnum=True,
                 asname=True,
@@ -548,13 +536,7 @@ class SatelliteTest(unittest.TestCase):
         controls_failed = False,
         received = [SatelliteAnswer(
             ip = '15.126.193.233',
-            matches_control=MatchesControl(
-                ip=False,
-                http=False,
-                cert=False,
-                asnum=False,
-                asname=False,
-            )
+            matches_control=MatchesControl()
         )],
         rcode = 0,
         date = '2021-03-01',
@@ -1068,7 +1050,6 @@ class SatelliteTest(unittest.TestCase):
             matches_control=MatchesControl(
                 ip=True,
                 http=True,
-                cert=False,
                 asnum=True,
                 asname=True,
             ),
@@ -1084,7 +1065,6 @@ class SatelliteTest(unittest.TestCase):
             matches_control=MatchesControl(
                 ip=True,
                 http=True,
-                cert=False,
                 asnum=True,
                 asname=True,
             ),
@@ -1272,13 +1252,7 @@ class SatelliteTest(unittest.TestCase):
         success = True,
         received = [SatelliteAnswer(
             ip = '104.20.161.134',
-            matches_control=MatchesControl(
-                ip=False,
-                http=False,
-                cert=False,
-                asnum=False,
-                asname=False,
-            ),
+            matches_control=MatchesControl(),
         )],
         date = '2020-09-02',
         ip_metadata = IpMetadata(
@@ -1300,7 +1274,6 @@ class SatelliteTest(unittest.TestCase):
                 matches_control=MatchesControl(
                     ip=True,
                     http=True,
-                    cert=False,
                     asnum=True,
                     asname=True,
                 ),
@@ -1315,7 +1288,6 @@ class SatelliteTest(unittest.TestCase):
                 matches_control=MatchesControl(
                     ip=True,
                     http=True,
-                    cert=False,
                     asnum=True,
                     asname=True,
                 ),
@@ -1330,7 +1302,6 @@ class SatelliteTest(unittest.TestCase):
                 matches_control=MatchesControl(
                     ip=True,
                     http=True,
-                    cert=False,
                     asnum=True,
                     asname=True,
                 ),
@@ -1345,7 +1316,6 @@ class SatelliteTest(unittest.TestCase):
                 matches_control=MatchesControl(
                     ip=True,
                     http=True,
-                    cert=False,
                     asnum=True,
                     asname=True,
                 ),
@@ -1371,13 +1341,7 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.38',
                 cert = None,
                 http = 'c5ba7f2da503045170f1d66c3e9f84576d8f3a606bb246db589a8f62c65921af',
-                matches_control=MatchesControl(
-                    ip=False,
-                    http=False,
-                    cert=False,
-                    asnum=False,
-                    asname=False,
-                ),
+                matches_control=MatchesControl(),
                 ip_metadata=IpMetadata(
                     asn=11111,
                     as_name='AS1'
@@ -1387,9 +1351,6 @@ class SatelliteTest(unittest.TestCase):
                 cert = 'cert',
                 http = '256e35b8bace0e9fe95f308deb35f82117cd7317f90a08f181516c31abe95b71',
                 matches_control=MatchesControl(
-                    ip=False,
-                    http=False,
-                    cert=False,
                     asnum=True,
                     asname=True,
                 ),
@@ -1404,7 +1365,6 @@ class SatelliteTest(unittest.TestCase):
                 matches_control=MatchesControl(
                     ip=True,
                     http=True,
-                    cert=False,
                     asnum=True,
                     asname=True,
                 ),
@@ -1419,7 +1379,6 @@ class SatelliteTest(unittest.TestCase):
                 matches_control=MatchesControl(
                     ip=True,
                     http=True,
-                    cert=False,
                     asnum=True,
                     asname=True,
                 ),
@@ -1476,13 +1435,7 @@ class SatelliteTest(unittest.TestCase):
         success = True,
         received = [SatelliteAnswer(
             ip = '104.20.161.134',
-            matches_control=MatchesControl(
-                ip=False,
-                http=False,
-                cert=False,
-                asnum=False,
-                asname=False,
-            ),
+            matches_control=MatchesControl(),
         )],
         date = '2020-09-02',
         ip_metadata = IpMetadata(
@@ -1501,13 +1454,7 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.38',
                 cert = None,
                 http = 'c5ba7f2da503045170f1d66c3e9f84576d8f3a606bb246db589a8f62c65921af',
-                matches_control=MatchesControl(
-                    ip=False,
-                    http=False,
-                    cert=False,
-                    asnum=False,
-                    asname=False,
-                ),
+                matches_control=MatchesControl(),
                 ip_metadata=IpMetadata(
                     asn=16509,
                     as_name='AMAZON-02'
@@ -1516,13 +1463,7 @@ class SatelliteTest(unittest.TestCase):
                 ip = '13.249.134.44',
                 cert = None,
                 http = '256e35b8bace0e9fe95f308deb35f82117cd7317f90a08f181516c31abe95b71',
-                matches_control=MatchesControl(
-                    ip=False,
-                    http=False,
-                    cert=False,
-                    asnum=False,
-                    asname=False,
-                ),
+                matches_control=MatchesControl(),
                 ip_metadata=IpMetadata(
                     asn=16509,
                     as_name='AMAZON-02'
@@ -1728,7 +1669,6 @@ class SatelliteTest(unittest.TestCase):
                     matches_control=MatchesControl(
                         ip=True,
                         http=True,
-                        cert=False,
                         asnum=True,
                         asname=True,
                     ),
@@ -1745,7 +1685,6 @@ class SatelliteTest(unittest.TestCase):
                     matches_control=MatchesControl(
                         ip=True,
                         http=True,
-                        cert=False,
                         asnum=True,
                         asname=True,
                     ),
@@ -1785,13 +1724,7 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.11",
                     http = "ecd1a8f3bd8db93d2d69e957cd3a114b43e8ba452d5cb2239f8eb6f6b92574ab",
                     cert = "",
-                    matches_control=MatchesControl(
-                        ip=False,
-                        http=False,
-                        cert=False,
-                        asnum=False,
-                        asname=False,
-                    ),
+                    matches_control=MatchesControl(),
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1801,13 +1734,7 @@ class SatelliteTest(unittest.TestCase):
                     ip = "104.31.16.118",
                     http = "7255d6747fcfdc1c16a30c0da7f039571d8a1bdefe2f56fa0ca243fc684fbbb8",
                     cert = "",
-                    matches_control=MatchesControl(
-                        ip=False,
-                        http=False,
-                        cert=False,
-                        asnum=False,
-                        asname=False,
-                    ),
+                    matches_control=MatchesControl(),
                     ip_metadata=IpMetadata(
                         asn=13335,
                         as_name="CLOUDFLARENET"
@@ -1846,7 +1773,6 @@ class SatelliteTest(unittest.TestCase):
                     matches_control=MatchesControl(
                         ip=True,
                         http=True,
-                        cert=False,
                         asnum=True,
                         asname=True,
                     ),
@@ -1863,7 +1789,6 @@ class SatelliteTest(unittest.TestCase):
                     matches_control=MatchesControl(
                         ip=True,
                         http=True,
-                        cert=False,
                         asnum=True,
                         asname=True,
                     ),
@@ -1906,7 +1831,6 @@ class SatelliteTest(unittest.TestCase):
                     matches_control=MatchesControl(
                         ip=True,
                         http=True,
-                        cert=False,
                         asnum=True,
                         asname=True,
                     ),
@@ -1923,7 +1847,6 @@ class SatelliteTest(unittest.TestCase):
                     matches_control=MatchesControl(
                         ip=True,
                         http=True,
-                        cert=False,
                         asnum=True,
                         asname=True,
                     ),
@@ -1963,13 +1886,7 @@ class SatelliteTest(unittest.TestCase):
                     ip = "188.186.157.49",
                     http = "177a8341782a57778766a7334d3e99ecb61ce54bbcc48838ddda846ea076726d",
                     cert = "",
-                    matches_control=MatchesControl(
-                        ip=False,
-                        http=False,
-                        cert=False,
-                        asnum=False,
-                        asname=False,
-                    ),
+                    matches_control=MatchesControl(),
                     match_confidence = 0,
                     ip_metadata=IpMetadata(
                         asn=31483,

--- a/pipeline/metadata/test_schema.py
+++ b/pipeline/metadata/test_schema.py
@@ -142,7 +142,13 @@ class SchemaTest(unittest.TestCase):
             ip = '13.249.134.38',
             cert = 'MII...',
             http = 'c5ba7f2da503045170f1d66c3e9f84576d8f3a606bb246db589a8f62c65921af',
-            matches_control = 'ip http asnum asname',
+            matches_control = schema.MatchesControl(
+              ip=True,
+              http=True,
+              cert=False,
+              asnum=True,
+              asname=True
+            ),
             match_confidence = 100,
             ip_metadata = schema.IpMetadata(
                 asn=16509,
@@ -156,14 +162,6 @@ class SchemaTest(unittest.TestCase):
               page_signature = 'x_example_fp',
               status = '200',
               body = 'example body',
-              tls_version = 123,
-              tls_cipher_suite = 3,
-              tls_cert = 'MII...',
-              tls_cert_common_name = None,
-              tls_cert_issuer = None,
-              tls_cert_start_date = None,
-              tls_cert_end_date = None,
-              tls_cert_alternative_names = [],
               headers = [
                 'Content-Language: en',
                 'X-Frame-Options: SAMEORIGIN',


### PR DESCRIPTION
For the [schema name changes](https://docs.google.com/document/d/1BMohMUiqJzYnTR8fdEqb1Ang5r1oW_aEHdsxQraQPR8/edit#).

Turn `matches_control`, which was a string field like `ip http asname` into a structured field of booleans like

```
{
 ip = True,
 http = True,
 cert = False,
 asnum = False,
 asname = True
}
```

Both internally in the code and externally in the bq schema.

