### PR TITLE
refactor adding metadata into its own class

### DIFF
--- a/pipeline/metadata/add_metadata.py
+++ b/pipeline/metadata/add_metadata.py
@@ -1,0 +1,96 @@
+"""Class for adding ip metadata to rows"""
+
+from __future__ import absolute_import
+
+import datetime
+from typing import List, Tuple, Iterator, Iterable
+
+import apache_beam as beam
+
+from pipeline.metadata.beam_metadata import DateIpKey, IP_METADATA_PCOLLECTION_NAME, ROWS_PCOLLECION_NAME, make_date_ip_key, merge_metadata_with_rows
+from pipeline.metadata.schema import BigqueryRow, IpMetadataWithKeys
+from pipeline.metadata.ip_metadata_chooser import IpMetadataChooserFactory
+
+
+class MetadataAdder():
+  """This class exists to provide access to the instantiated IpMetadata inside a beam operation."""
+
+  def __init__(self,
+               metadata_chooser_factory: IpMetadataChooserFactory) -> None:
+    self.metadata_chooser_factory = metadata_chooser_factory
+
+  def add_metadata(
+      self, rows: beam.pvalue.PCollection[BigqueryRow]
+  ) -> beam.pvalue.PCollection[BigqueryRow]:
+    """Add ip metadata to a collection of roundtrip rows.
+
+    Args:
+      rows: beam.PCollection[BigqueryRow]
+
+    Returns:
+      PCollection[BigqueryRow]
+      The same rows as above with with additional metadata columns added.
+    """
+
+    # PCollection[Tuple[DateIpKey,BigqueryRow]]
+    rows_keyed_by_ip_and_date = (
+        rows | 'key by ips and dates' >>
+        beam.Map(lambda row: (make_date_ip_key(row), row)).with_output_types(
+            Tuple[DateIpKey, BigqueryRow]))
+
+    # PCollection[DateIpKey]
+    # pylint: disable=no-value-for-parameter
+    ips_and_dates = (
+        rows_keyed_by_ip_and_date | 'get ip and date keys per row' >>
+        beam.Keys().with_output_types(DateIpKey))
+
+    # PCollection[DateIpKey]
+    deduped_ips_and_dates = (
+        # pylint: disable=no-value-for-parameter
+        ips_and_dates | 'dedup' >> beam.Distinct().with_output_types(DateIpKey))
+
+    # PCollection[Tuple[date,List[ip]]]
+    grouped_ips_by_dates = (
+        deduped_ips_and_dates | 'group by date' >>
+        beam.GroupByKey().with_output_types(Tuple[str, Iterable[str]]))
+
+    # PCollection[Tuple[DateIpKey,IpMetadataWithKeys]]
+    ips_with_metadata = (
+        grouped_ips_by_dates | 'get ip metadata' >> beam.FlatMapTuple(
+            self._add_ip_metadata).with_output_types(Tuple[DateIpKey,
+                                                           IpMetadataWithKeys]))
+
+    # PCollection[Tuple[Tuple[date,ip],Dict[input_name_key,List[BigqueryRow|IpMetadataWithKeys]]]]
+    grouped_metadata_and_rows = (({
+        IP_METADATA_PCOLLECTION_NAME: ips_with_metadata,
+        ROWS_PCOLLECION_NAME: rows_keyed_by_ip_and_date
+    }) | 'group by keys' >> beam.CoGroupByKey())
+
+    # PCollection[BigqueryRow]
+    rows_with_metadata = (
+        grouped_metadata_and_rows |
+        'merge metadata with rows' >> beam.FlatMapTuple(
+            merge_metadata_with_rows).with_output_types(BigqueryRow))
+
+    return rows_with_metadata
+
+  def _add_ip_metadata(
+      self, date: str,
+      ips: List[str]) -> Iterator[Tuple[DateIpKey, IpMetadataWithKeys]]:
+    """Add Autonymous System metadata for ips in the given rows.
+
+    Args:
+      date: a 'YYYY-MM-DD' date key
+      ips: a list of ips
+
+    Yields:
+      Tuples (DateIpKey, IpMetadataWithKeys)
+    """
+    ip_metadata_chooser = self.metadata_chooser_factory.make_chooser(
+        datetime.date.fromisoformat(date))
+
+    for ip in ips:
+      metadata_key = (date, ip)
+      metadata_values = ip_metadata_chooser.get_metadata(ip)
+
+      yield (metadata_key, metadata_values)

--- a/pipeline/metadata/hyperquack.py
+++ b/pipeline/metadata/hyperquack.py
@@ -1,0 +1,26 @@
+"""Beam pipeline steps for hyperquack data"""
+
+from __future__ import absolute_import
+
+from typing import Tuple
+
+import apache_beam as beam
+
+from pipeline.metadata import flatten
+from pipeline.metadata.schema import HyperquackRow
+from pipeline.metadata.add_metadata import MetadataAdder
+
+
+def process_hyperquack_lines(
+    lines: beam.pvalue.PCollection[Tuple[str, str]],
+    metadata_adder: MetadataAdder) -> beam.pvalue.PCollection[HyperquackRow]:
+  """Process hyperquack data."""
+
+  rows = (
+      lines | 'flatten json' >> beam.ParDo(
+          flatten.FlattenMeasurement()).with_output_types(HyperquackRow))
+
+  # PCollection[HyperquackRow|SatelliteRow]
+  rows_with_metadata = metadata_adder.add_metadata(rows)
+
+  return rows_with_metadata

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -6,7 +6,7 @@ import datetime
 import json
 import logging
 import re
-from typing import List, Tuple, Dict, Iterator, Iterable
+from typing import List, Dict, Tuple, Iterator, Iterable
 import uuid
 
 import apache_beam as beam
@@ -16,6 +16,7 @@ from pipeline.metadata.schema import SatelliteRow, SatelliteAnswer, SatelliteAns
 from pipeline.metadata.lookup_country_code import country_name_to_code
 from pipeline.metadata import flatten_satellite
 from pipeline.metadata import flatten
+from pipeline.metadata.add_metadata import MetadataAdder
 
 # Data files for the Satellite pipeline
 SATELLITE_RESOLVERS_FILE = 'resolvers.json'  #v1, v2.2
@@ -812,8 +813,8 @@ def _verify(scan: SatelliteRow) -> SatelliteRow:
 
 
 def process_satellite_lines(
-    lines: beam.pvalue.PCollection[Tuple[str, str]]
-) -> beam.pvalue.PCollection[SatelliteRow]:
+    lines: beam.pvalue.PCollection[Tuple[str, str]],
+    metadata_adder: MetadataAdder) -> beam.pvalue.PCollection[SatelliteRow]:
   """Process both satellite and page fetch data files.
 
   Args:
@@ -841,4 +842,6 @@ def process_satellite_lines(
   post_processed_satellite = post_processing_satellite(
       satellite_with_page_fetches)
 
-  return post_processed_satellite
+  rows_with_metadata = metadata_adder.add_metadata(post_processed_satellite)
+
+  return rows_with_metadata

--- a/pipeline/metadata/test_add_metadata.py
+++ b/pipeline/metadata/test_add_metadata.py
@@ -1,0 +1,177 @@
+"""Unit tests for adding ip metadata"""
+
+from __future__ import absolute_import
+
+import unittest
+
+import apache_beam as beam
+from apache_beam.testing.test_pipeline import TestPipeline
+import apache_beam.testing.util as beam_test_util
+
+from pipeline.metadata.schema import BigqueryRow, IpMetadata, IpMetadataWithKeys
+from pipeline.metadata.ip_metadata_chooser import FakeIpMetadataChooserFactory
+from pipeline.metadata import satellite
+from pipeline.metadata.add_metadata import MetadataAdder
+
+
+class MetadataAdderTest(unittest.TestCase):
+  """Unit tests for adding ip metadata."""
+
+  def test_add_metadata(self) -> None:  # pylint: disable=no-self-use
+    """Test adding IP metadata to mesurements."""
+    rows = [
+        BigqueryRow(
+            domain='www.example.com',
+            ip='8.8.8.8',
+            date='2020-01-01',
+            success=True,
+        ),
+        BigqueryRow(
+            domain='www.example.com',
+            ip='1.1.1.1',
+            date='2020-01-01',
+            success=False,
+        ),
+        BigqueryRow(
+            domain='www.example.com',
+            ip='8.8.8.8',
+            date='2020-01-02',
+            success=False,
+        ),
+        BigqueryRow(
+            domain='www.example.com',
+            ip='1.1.1.1',
+            date='2020-01-02',
+            success=True,
+        )
+    ]
+
+    p = TestPipeline()
+    rows = (p | beam.Create(rows))
+
+    adder = MetadataAdder(FakeIpMetadataChooserFactory())
+    rows_with_metadata = adder.add_metadata(rows)
+
+    expected = [
+        BigqueryRow(
+            domain='www.example.com',
+            ip='8.8.8.8',
+            date='2020-01-01',
+            success=True,
+            ip_metadata=IpMetadata(
+                netblock='8.8.8.0/24',
+                asn=15169,
+                as_name='GOOGLE',
+                as_full_name='Google LLC',
+                as_class='Content',
+                country='US',
+            )),
+        BigqueryRow(
+            domain='www.example.com',
+            ip='1.1.1.1',
+            date='2020-01-01',
+            success=False,
+            ip_metadata=IpMetadata(
+                netblock='1.0.0.1/24',
+                asn=13335,
+                as_name='CLOUDFLARENET',
+                as_full_name='Cloudflare Inc.',
+                as_class='Content',
+                country='US',
+            )),
+        BigqueryRow(
+            domain='www.example.com',
+            ip='8.8.8.8',
+            date='2020-01-02',
+            success=False,
+            ip_metadata=IpMetadata(
+                netblock='8.8.8.0/24',
+                asn=15169,
+                as_name='GOOGLE',
+                as_full_name='Google LLC',
+                as_class='Content',
+                country='US',
+            )),
+        BigqueryRow(
+            domain='www.example.com',
+            ip='1.1.1.1',
+            date='2020-01-02',
+            success=True,
+            ip_metadata=IpMetadata(
+                netblock='1.0.0.1/24',
+                asn=13335,
+                as_name='CLOUDFLARENET',
+                as_full_name='Cloudflare Inc.',
+                as_class='Content',
+                country='US',
+            ))
+    ]
+
+    beam_test_util.assert_that(rows_with_metadata,
+                               beam_test_util.equal_to(expected))
+
+  # pylint: disable=protected-access
+
+  def test_add_ip_metadata_caida(self) -> None:
+    """Test merging given IP metadata with given measurements."""
+    adder = MetadataAdder(FakeIpMetadataChooserFactory())
+    metadatas = list(
+        adder._add_ip_metadata('2020-01-01', ['1.1.1.1', '8.8.8.8']))
+
+    expected_key_1: satellite.DateIpKey = ('2020-01-01', '1.1.1.1')
+    expected_value_1 = IpMetadataWithKeys(
+        ip='1.1.1.1',
+        date='2020-01-01',
+        netblock='1.0.0.1/24',
+        asn=13335,
+        as_name='CLOUDFLARENET',
+        as_full_name='Cloudflare Inc.',
+        as_class='Content',
+        country='US',
+        organization='Fake Cloudflare Sub-Org',
+    )
+
+    expected_key_2: satellite.DateIpKey = ('2020-01-01', '8.8.8.8')
+    expected_value_2 = IpMetadataWithKeys(
+        ip='8.8.8.8',
+        date='2020-01-01',
+        netblock='8.8.8.0/24',
+        asn=15169,
+        as_name='GOOGLE',
+        as_full_name='Google LLC',
+        as_class='Content',
+        country='US',
+        # No organization data is added since the ASN doesn't match dbip
+    )
+
+    self.assertListEqual(metadatas, [(expected_key_1, expected_value_1),
+                                     (expected_key_2, expected_value_2)])
+
+  def disabled_test_add_ip_metadata_maxmind(self) -> None:
+    """Test merging given IP metadata with given measurements."""
+    # TODO turn back on once maxmind is reenabled.
+
+    adder = MetadataAdder(FakeIpMetadataChooserFactory())
+    metadatas = list(adder._add_ip_metadata('2020-01-01', ['1.1.1.3']))
+
+    # Test Maxmind lookup when country data is missing
+    # Cloudflare IPs return Australia
+    expected_key_1 = ('2020-01-01', '1.1.1.3')
+    expected_value_1 = IpMetadataWithKeys(
+        ip='1.1.1.3',
+        date='2020-01-01',
+        netblock='1.0.0.1/24',
+        asn=13335,
+        as_name='CLOUDFLARENET',
+        as_full_name='Cloudflare Inc.',
+        as_class='Content',
+        organization='Fake Cloudflare Sub-Org',
+        country='AU')
+
+    self.assertListEqual(metadatas, [(expected_key_1, expected_value_1)])
+
+  # pylint: enable=protected-access
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -13,18 +13,16 @@
 # limitations under the License.
 """Unit tests for the beam pipeline."""
 
+from __future__ import absolute_import
+
 import datetime
 import unittest
-
-import apache_beam as beam
 
 from apache_beam.testing.test_pipeline import TestPipeline
 import apache_beam.testing.util as beam_test_util
 
-from pipeline.metadata.schema import BigqueryRow, IpMetadata, IpMetadataWithKeys
 from pipeline import beam_tables
 from pipeline.metadata.ip_metadata_chooser import FakeIpMetadataChooserFactory
-from pipeline.metadata import satellite
 
 
 class PipelineMainTest(unittest.TestCase):
@@ -32,8 +30,6 @@ class PipelineMainTest(unittest.TestCase):
 
   def setUp(self) -> None:
     self.maxDiff = None  # pylint: disable=invalid-name
-
-  # pylint: disable=protected-access
 
   def test_get_table_name(self) -> None:
     """Test creating a table name given params."""
@@ -69,6 +65,8 @@ class PipelineMainTest(unittest.TestCase):
     self.assertEqual(
         beam_tables.get_job_name('laplante.scan_https', True),
         'append-laplante-scan-https')
+
+  # pylint: disable=protected-access
 
   def test_get_full_table_name(self) -> None:
     project = 'firehook-censoredplanet'
@@ -124,163 +122,6 @@ class PipelineMainTest(unittest.TestCase):
         beam_tables._between_dates(filename, None, datetime.date(2020, 5, 10)))
     self.assertFalse(
         beam_tables._between_dates(filename, datetime.date(2020, 5, 12), None))
-
-  def test_add_metadata(self) -> None:  # pylint: disable=no-self-use
-    """Test adding IP metadata to mesurements."""
-    rows = [
-        BigqueryRow(
-            domain='www.example.com',
-            ip='8.8.8.8',
-            date='2020-01-01',
-            success=True,
-        ),
-        BigqueryRow(
-            domain='www.example.com',
-            ip='1.1.1.1',
-            date='2020-01-01',
-            success=False,
-        ),
-        BigqueryRow(
-            domain='www.example.com',
-            ip='8.8.8.8',
-            date='2020-01-02',
-            success=False,
-        ),
-        BigqueryRow(
-            domain='www.example.com',
-            ip='1.1.1.1',
-            date='2020-01-02',
-            success=True,
-        )
-    ]
-
-    p = TestPipeline()
-    rows = (p | beam.Create(rows))
-
-    runner = beam_tables.ScanDataBeamPipelineRunner(
-        '', '', '', '', FakeIpMetadataChooserFactory())
-
-    rows_with_metadata = runner._add_metadata(rows)
-
-    expected = [
-        BigqueryRow(
-            domain='www.example.com',
-            ip='8.8.8.8',
-            date='2020-01-01',
-            success=True,
-            ip_metadata=IpMetadata(
-                netblock='8.8.8.0/24',
-                asn=15169,
-                as_name='GOOGLE',
-                as_full_name='Google LLC',
-                as_class='Content',
-                country='US',
-            )),
-        BigqueryRow(
-            domain='www.example.com',
-            ip='1.1.1.1',
-            date='2020-01-01',
-            success=False,
-            ip_metadata=IpMetadata(
-                netblock='1.0.0.1/24',
-                asn=13335,
-                as_name='CLOUDFLARENET',
-                as_full_name='Cloudflare Inc.',
-                as_class='Content',
-                country='US',
-            )),
-        BigqueryRow(
-            domain='www.example.com',
-            ip='8.8.8.8',
-            date='2020-01-02',
-            success=False,
-            ip_metadata=IpMetadata(
-                netblock='8.8.8.0/24',
-                asn=15169,
-                as_name='GOOGLE',
-                as_full_name='Google LLC',
-                as_class='Content',
-                country='US',
-            )),
-        BigqueryRow(
-            domain='www.example.com',
-            ip='1.1.1.1',
-            date='2020-01-02',
-            success=True,
-            ip_metadata=IpMetadata(
-                netblock='1.0.0.1/24',
-                asn=13335,
-                as_name='CLOUDFLARENET',
-                as_full_name='Cloudflare Inc.',
-                as_class='Content',
-                country='US',
-            ))
-    ]
-
-    beam_test_util.assert_that(rows_with_metadata,
-                               beam_test_util.equal_to(expected))
-
-  def test_add_ip_metadata_caida(self) -> None:
-    """Test merging given IP metadata with given measurements."""
-    runner = beam_tables.ScanDataBeamPipelineRunner(
-        '', '', '', '', FakeIpMetadataChooserFactory())
-
-    metadatas = list(
-        runner._add_ip_metadata('2020-01-01', ['1.1.1.1', '8.8.8.8']))
-
-    expected_key_1: satellite.DateIpKey = ('2020-01-01', '1.1.1.1')
-    expected_value_1 = IpMetadataWithKeys(
-        ip='1.1.1.1',
-        date='2020-01-01',
-        netblock='1.0.0.1/24',
-        asn=13335,
-        as_name='CLOUDFLARENET',
-        as_full_name='Cloudflare Inc.',
-        as_class='Content',
-        country='US',
-        organization='Fake Cloudflare Sub-Org',
-    )
-
-    expected_key_2: satellite.DateIpKey = ('2020-01-01', '8.8.8.8')
-    expected_value_2 = IpMetadataWithKeys(
-        ip='8.8.8.8',
-        date='2020-01-01',
-        netblock='8.8.8.0/24',
-        asn=15169,
-        as_name='GOOGLE',
-        as_full_name='Google LLC',
-        as_class='Content',
-        country='US',
-        # No organization data is added since the ASN doesn't match dbip
-    )
-
-    self.assertListEqual(metadatas, [(expected_key_1, expected_value_1),
-                                     (expected_key_2, expected_value_2)])
-
-  def disabled_test_add_ip_metadata_maxmind(self) -> None:
-    """Test merging given IP metadata with given measurements."""
-    # TODO turn back on once maxmind is reenabled.
-
-    runner = beam_tables.ScanDataBeamPipelineRunner(
-        '', '', '', '', FakeIpMetadataChooserFactory())
-
-    metadatas = list(runner._add_ip_metadata('2020-01-01', ['1.1.1.3']))
-
-    # Test Maxmind lookup when country data is missing
-    # Cloudflare IPs return Australia
-    expected_key_1 = ('2020-01-01', '1.1.1.3')
-    expected_value_1 = IpMetadataWithKeys(
-        ip='1.1.1.3',
-        date='2020-01-01',
-        netblock='1.0.0.1/24',
-        asn=13335,
-        as_name='CLOUDFLARENET',
-        as_full_name='Cloudflare Inc.',
-        as_class='Content',
-        organization='Fake Cloudflare Sub-Org',
-        country='AU')
-
-    self.assertListEqual(metadatas, [(expected_key_1, expected_value_1)])
 
   # pylint: enable=protected-access
 


### PR DESCRIPTION
This is a refactoring to enable the change you're asking for in https://github.com/censoredplanet/censoredplanet-analysis/pull/151#pullrequestreview-944834890. We've discussed making this change before, but I hadn't gotten to it.

This removes the top-level steps of the hyperquack and satellite pipelines from `beam_tables.py` and isolates them entirely in the `hyperquack.py` and `satellite.py files.

This requires moving `add_metadata` from `beam_tables.py` (which didn't make much sense there anyway) into its own class in `add_metadata.py`

Sorry to send nesting-doll PRs 😅