### PR TITLE
upgrade apache-beam

### DIFF
--- a/pipeline/setup.py
+++ b/pipeline/setup.py
@@ -18,7 +18,7 @@ import setuptools
 setuptools.setup(
     name='censoredplanet-analysis',
     version='0.0.1',
-    install_requires=['cryptography==36.0.2', 'geoip2==4.1.0', 'pyasn==1.6.1'],
+    install_requires=['cryptography==37.0.2', 'geoip2==4.1.0', 'pyasn==1.6.1'],
     # Add a prefix so absolute import succeeds on workers.
     packages=['pipeline', 'pipeline.metadata'],
     package_dir={

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-apache-beam==2.33.0
-apache-beam[gcp]==2.33.0
+apache-beam==2.38.0
+apache-beam[gcp]==2.38.0
 # Maxmind
 geoip2==4.1.0
 # Imports GCS client needed for beam
@@ -15,4 +15,4 @@ pyasn==1.6.1
 requests==2.24.0
 retry==0.9.2
 schedule==0.6.0
-cryptography==36.0.2
+cryptography==37.0.2


### PR DESCRIPTION
This upgrade was recommended due to a beam/gcp bug with versions 2.32.0 – 2.37.0. 

https://cloud.google.com/dataflow/docs/support/sdk-version-support-status#python

Tested that I was able to start up a docker job with these versions