### PR TITLE
fix recent lint and test problems from newer versions

### DIFF
--- a/pipeline/metadata/flatten_base.py
+++ b/pipeline/metadata/flatten_base.py
@@ -35,7 +35,7 @@ def get_common_name(cert_name: x509.Name) -> Optional[str]:
   try:
     attributes = cert_name.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)
     if attributes:
-      return attributes[0].value
+      return str(attributes[0].value)
   except x509.AttributeNotFound:
     logging.warning('x509.AttributeNotFound: Common Name\n')
   return None

--- a/pipeline/metadata/test_flatten_base.py
+++ b/pipeline/metadata/test_flatten_base.py
@@ -177,12 +177,8 @@ class FlattenBaseTest(unittest.TestCase):
     cert_str = "invalid certificate text"
     with self.assertLogs(level='WARNING') as cm:
       parsed = flatten_base.parse_cert(cert_str)
-      self.assertEqual(
-          cm.output[0], 'WARNING:root:ValueError: '
-          'Unable to load PEM file. '
-          'See https://cryptography.io/en/latest/faq.html#why-can-t-i-import-my-pem-file '
-          'for more details. InvalidData(InvalidByte(7, 32))\n'
-          'Cert: invalid certificate text\n')
+      self.assertIn('Unable to load PEM file.', cm.output[0])
+      self.assertIn('Cert: invalid certificate text', cm.output[0])
     expected: Tuple[Optional[str], Optional[str], Optional[str], Optional[str],
                     List[str]] = (None, None, None, None, [])
     self.assertEqual(parsed, expected)


### PR DESCRIPTION
Github checks were failing due to newer versions of mypy/type stubs/cryptography libraries