### PR TITLE
turn satellite pipeline on in production

### DIFF
--- a/pipeline/run_beam_tables.py
+++ b/pipeline/run_beam_tables.py
@@ -103,8 +103,6 @@ def main(parsed_args: argparse.Namespace) -> None:
 
   if parsed_args.scan_type == 'all':
     selected_scan_types = list(beam_tables.ALL_SCAN_TYPES)
-    # TODO turn back on Satellite once it works in the cloud.
-    selected_scan_types.remove('satellite')
   else:
     selected_scan_types = [parsed_args.scan_type]
 

--- a/pipeline/test_run_beam_tables.py
+++ b/pipeline/test_run_beam_tables.py
@@ -81,10 +81,12 @@ class RunBeamTablesTest(unittest.TestCase):
                    None, None)
       call4 = call('https', True, 'append-base-https-scan', 'base.https_scan',
                    None, None)
+      call5 = call('satellite', True, 'append-base-satellite-scan',
+                   'base.satellite_scan', None, None)
       mock_runner.run_beam_pipeline.assert_has_calls(
-          [call1, call2, call3, call4], any_order=True)
+          [call1, call2, call3, call4, call5], any_order=True)
       # No extra calls
-      self.assertEqual(4, mock_runner.run_beam_pipeline.call_count)
+      self.assertEqual(5, mock_runner.run_beam_pipeline.call_count)
 
   def test_main_user_dates(self) -> None:
     """Test arg parsing for a user pipeline with dates."""


### PR DESCRIPTION
Now that the satellite schema is mostly stable we should start running a nightly pipeline. This will help us have more up-to-date data and to catch any new issues in the code/data format faster.