### PR TITLE
annotate satellite answers with metadata from routeviews

### DIFF
--- a/pipeline/metadata/add_metadata.py
+++ b/pipeline/metadata/add_metadata.py
@@ -113,45 +113,12 @@ class MetadataAdder():
       self, rows: beam.pvalue.PCollection[SatelliteRow]
   ) -> beam.pvalue.PCollection[SatelliteRow]:
     """Add ip metadata info to received ip lists in rows
+
     Args:
-      rows: PCollection of dicts without metadata in the received ips like:
-        {
-          'ip': '1.2.3.4'
-          'domain': 'ex.com'
-          'received' : [{
-              ip: '4.5.6.7'
-              ip_metadata: Old_IP_Metadata
-            }, {
-              ip: '5.6.7.8'
-            },
-          ]
-        }
-      tags: PCollection of received ip metadata like:
-        {
-          'ip': '4.5.6.7'
-          'asname': 'AMAZON-AES',
-          'asnum': 14618,
-        }
-        {
-          'ip': '5.6.7.8'
-          'asname': 'CLOUDFLARE',
-          'asnum': 13335,
-        }
-    Returns a PCollection of rows with metadata tags added to received ips like
-      {
-        'ip': '1.2.3.4'
-        'domain': 'ex.com'
-        'received' : [{
-            'ip': '4.5.6.7'
-            'asname': 'AMAZON-AES',
-            'asnum': 14618,
-          }, {
-            'ip': '5.6.7.8'
-            'asname': 'CLOUDFLARE',
-            'asnum': 13335,
-          },
-        ]
-      }
+      rows: PCollection of SatelliteRows
+
+    Returns:
+      SatelliteRows with routeview metadata attatched to answer ips.
     """
     # PCollection[Tuple[roundtrip_id, SatelliteRow]]
     rows_with_roundtrip_id = (

--- a/pipeline/metadata/add_metadata.py
+++ b/pipeline/metadata/add_metadata.py
@@ -13,7 +13,7 @@ from pipeline.metadata.schema import BigqueryRow, IpMetadataWithDateKey, Satelli
 from pipeline.metadata.ip_metadata_chooser import IpMetadataChooserFactory
 
 
-def _set_random_roundtrip_id(row: SatelliteRow) -> Tuple[str, SatelliteRow]:
+def set_random_roundtrip_id(row: SatelliteRow) -> Tuple[str, SatelliteRow]:
   """Add a roundtrip_id field to a row."""
   roundtrip_id = uuid.uuid4().hex
   return (roundtrip_id, row)
@@ -123,7 +123,7 @@ class MetadataAdder():
     # PCollection[Tuple[roundtrip_id, SatelliteRow]]
     rows_with_roundtrip_id = (
         rows | 'add roundtrip_ids: answer metadata' >>
-        beam.Map(_set_random_roundtrip_id).with_output_types(
+        beam.Map(set_random_roundtrip_id).with_output_types(
             Tuple[str, SatelliteRow]))
 
     # PCollection[Tuple[DateIpKey, Tuple[roundtrip_id, SatelliteAnswer]]]

--- a/pipeline/metadata/add_metadata.py
+++ b/pipeline/metadata/add_metadata.py
@@ -4,12 +4,46 @@ from __future__ import absolute_import
 
 import datetime
 from typing import List, Tuple, Iterator, Iterable
+import uuid
 
 import apache_beam as beam
 
-from pipeline.metadata.beam_metadata import DateIpKey, IP_METADATA_PCOLLECTION_NAME, ROWS_PCOLLECION_NAME, make_date_ip_key, merge_metadata_with_rows
-from pipeline.metadata.schema import BigqueryRow, IpMetadataWithKeys
+from pipeline.metadata.beam_metadata import DateIpKey, IP_METADATA_PCOLLECTION_NAME, ROWS_PCOLLECION_NAME, RECEIVED_IPS_PCOLLECTION_NAME, make_date_ip_key, merge_metadata_with_rows, merge_tagged_answers_with_rows, merge_satellite_metadata_with_answers
+from pipeline.metadata.schema import BigqueryRow, IpMetadataWithDateKey, SatelliteRow, SatelliteAnswer, SatelliteAnswerWithDateKey
 from pipeline.metadata.ip_metadata_chooser import IpMetadataChooserFactory
+
+
+def _set_random_roundtrip_id(row: SatelliteRow) -> Tuple[str, SatelliteRow]:
+  """Add a roundtrip_id field to a row."""
+  roundtrip_id = uuid.uuid4().hex
+  return (roundtrip_id, row)
+
+
+def _get_received_ips_with_roundtrip_id_and_date(
+    row_with_id: Tuple[str, SatelliteRow]
+) -> Iterable[Tuple[DateIpKey, Tuple[str, SatelliteAnswer]]]:
+  """Get all the individual received ips answers from a row.
+
+  Args:
+    row_with_id Tuple[roundtrip_id, SatelliteRow]
+
+  Yields individual recieved answers that also include the roundtrip and source
+    ex:
+      Tuple(
+        Tuple('2022-01-02', '1.2.3.4')
+        Tuple('abc' # roundtrip id
+              SatelliteAnswer(ip: '1.2.3.4')))
+      Tuple(
+        Tuple('2022-01-02', '4.5.6.7')
+        Tuple('abc' # roundtrip id
+              SatelliteAnswer(ip: '4.5.6.7')))
+  """
+  (roundtrip_id, row) = row_with_id
+  date = row.date or ''
+
+  for answer in row.received:
+    key: DateIpKey = (date, answer.ip)
+    yield (key, (roundtrip_id, answer))
 
 
 class MetadataAdder():
@@ -54,13 +88,13 @@ class MetadataAdder():
         deduped_ips_and_dates | 'group by date' >>
         beam.GroupByKey().with_output_types(Tuple[str, Iterable[str]]))
 
-    # PCollection[Tuple[DateIpKey,IpMetadataWithKeys]]
+    # PCollection[Tuple[DateIpKey,IpMetadataWithDateKey]]
     ips_with_metadata = (
         grouped_ips_by_dates | 'get ip metadata' >> beam.FlatMapTuple(
             self._annotate_ips).with_output_types(Tuple[DateIpKey,
-                                                        IpMetadataWithKeys]))
+                                                        IpMetadataWithDateKey]))
 
-    # PCollection[Tuple[Tuple[date,ip],Dict[input_name_key,List[BigqueryRow|IpMetadataWithKeys]]]]
+    # PCollection[Tuple[Tuple[date,ip],Dict[input_name_key,List[BigqueryRow|IpMetadataWithDateKey]]]]
     grouped_metadata_and_rows = (({
         IP_METADATA_PCOLLECTION_NAME: ips_with_metadata,
         ROWS_PCOLLECION_NAME: rows_keyed_by_ip_and_date
@@ -75,9 +109,119 @@ class MetadataAdder():
 
     return rows_with_metadata
 
+  def annotate_answer_ips(
+      self, rows: beam.pvalue.PCollection[SatelliteRow]
+  ) -> beam.pvalue.PCollection[SatelliteRow]:
+    """Add ip metadata info to received ip lists in rows
+    Args:
+      rows: PCollection of dicts without metadata in the received ips like:
+        {
+          'ip': '1.2.3.4'
+          'domain': 'ex.com'
+          'received' : [{
+              ip: '4.5.6.7'
+              ip_metadata: Old_IP_Metadata
+            }, {
+              ip: '5.6.7.8'
+            },
+          ]
+        }
+      tags: PCollection of received ip metadata like:
+        {
+          'ip': '4.5.6.7'
+          'asname': 'AMAZON-AES',
+          'asnum': 14618,
+        }
+        {
+          'ip': '5.6.7.8'
+          'asname': 'CLOUDFLARE',
+          'asnum': 13335,
+        }
+    Returns a PCollection of rows with metadata tags added to received ips like
+      {
+        'ip': '1.2.3.4'
+        'domain': 'ex.com'
+        'received' : [{
+            'ip': '4.5.6.7'
+            'asname': 'AMAZON-AES',
+            'asnum': 14618,
+          }, {
+            'ip': '5.6.7.8'
+            'asname': 'CLOUDFLARE',
+            'asnum': 13335,
+          },
+        ]
+      }
+    """
+    # PCollection[Tuple[roundtrip_id, SatelliteRow]]
+    rows_with_roundtrip_id = (
+        rows | 'add roundtrip_ids' >>
+        beam.Map(_set_random_roundtrip_id).with_output_types(
+            Tuple[str, SatelliteRow]))
+
+    # PCollection[Tuple[DateIpKey, Tuple[roundtrip_id, SatelliteAnswer]]]
+    received_ips_keyed_by_ip_and_date = (
+        rows_with_roundtrip_id | 'get received ips' >> beam.FlatMap(
+            _get_received_ips_with_roundtrip_id_and_date).with_output_types(
+                Tuple[DateIpKey, Tuple[str, SatelliteAnswer]]))
+
+    #PCollection[DateIpKey]
+    # pylint: disable=no-value-for-parameter
+    ips_and_dates = (
+        received_ips_keyed_by_ip_and_date | 'get ip and date keys per answer' >>
+        beam.Keys().with_output_types(DateIpKey))
+
+    # PCollection[DateIpKey]
+    deduped_ips_and_dates = (
+        # pylint: disable=no-value-for-parameter
+        ips_and_dates |
+        'dedup answer ips' >> beam.Distinct().with_output_types(DateIpKey))
+
+    # PCollection[Tuple[date,List[ip]]]
+    grouped_ips_by_dates = (
+        deduped_ips_and_dates | 'group answer ips by date' >>
+        beam.GroupByKey().with_output_types(Tuple[str, Iterable[str]]))
+
+    # PCollection[Tuple[DateIpKey,IpMetadataWithDateKey]]
+    ips_with_metadata = (
+        grouped_ips_by_dates | 'get ip metadata for answers' >>
+        beam.FlatMapTuple(self._annotate_ips).with_output_types(
+            Tuple[DateIpKey, IpMetadataWithDateKey]))
+
+    grouped_metadata_and_received_ips = (({
+        IP_METADATA_PCOLLECTION_NAME: ips_with_metadata,
+        RECEIVED_IPS_PCOLLECTION_NAME: received_ips_keyed_by_ip_and_date
+    }) | 'add received ip metadata: group by keys' >> beam.CoGroupByKey())
+
+    # PCollection[Tuple[roundtrip_id, SatelliteAnswerWithDateKey]] received ip row with
+    received_ips_with_metadata = (
+        grouped_metadata_and_received_ips |
+        'add received ip metadata: merge tags with answers' >> beam.
+        FlatMapTuple(merge_satellite_metadata_with_answers).with_output_types(
+            Tuple[str, SatelliteAnswerWithDateKey]))
+
+    # PCollection[Tuple[roundtrip_id, List[Tuple[roundtrip_id, SatelliteAnswerWithDateKey]]]]
+    received_ips_grouped_by_roundtrip_ip = (
+        received_ips_with_metadata | 'group received_by roundtrip' >>
+        beam.GroupBy(lambda x: x[0]).with_output_types(
+            Tuple[str, Iterable[Tuple[str, SatelliteAnswerWithDateKey]]]))
+
+    grouped_rows_and_received_ips = (({
+        ROWS_PCOLLECION_NAME: rows_with_roundtrip_id,
+        RECEIVED_IPS_PCOLLECTION_NAME: received_ips_grouped_by_roundtrip_ip
+    }) | 'add received ip tags: group by roundtrip' >> beam.CoGroupByKey())
+
+    # PCollection[SatelliteRow] received ip row with roundtrip id
+    rows_with_metadata = (
+        grouped_rows_and_received_ips |
+        'add received ip tags: add tagged answers back' >> beam.MapTuple(
+            merge_tagged_answers_with_rows).with_output_types(SatelliteRow))
+
+    return rows_with_metadata
+
   def _annotate_ips(
       self, date: str,
-      ips: List[str]) -> Iterator[Tuple[DateIpKey, IpMetadataWithKeys]]:
+      ips: List[str]) -> Iterator[Tuple[DateIpKey, IpMetadataWithDateKey]]:
     """Add Autonymous System metadata for ips in the given rows.
 
     Args:
@@ -85,7 +229,7 @@ class MetadataAdder():
       ips: a list of ips
 
     Yields:
-      Tuples (DateIpKey, IpMetadataWithKeys)
+      Tuples (DateIpKey, IpMetadataWithDateKey)
     """
     ip_metadata_chooser = self.metadata_chooser_factory.make_chooser(
         datetime.date.fromisoformat(date))

--- a/pipeline/metadata/add_metadata.py
+++ b/pipeline/metadata/add_metadata.py
@@ -39,10 +39,10 @@ def _get_received_ips_with_roundtrip_id_and_date(
               SatelliteAnswer(ip: '4.5.6.7')))
   """
   (roundtrip_id, row) = row_with_id
-  date = row.date or ''
+  roundtrip_date = row.date or ''
 
   for answer in row.received:
-    key: DateIpKey = (date, answer.ip)
+    key: DateIpKey = (roundtrip_date, answer.ip)
     yield (key, (roundtrip_id, answer))
 
 
@@ -161,7 +161,7 @@ class MetadataAdder():
         RECEIVED_IPS_PCOLLECTION_NAME: received_ips_keyed_by_ip_and_date
     }) | 'add received ip metadata: group by keys' >> beam.CoGroupByKey())
 
-    # PCollection[Tuple[roundtrip_id, SatelliteAnswerWithDateKey]] received ip row with
+    # PCollection[Tuple[roundtrip_id, SatelliteAnswerWithDateKey]]
     received_ips_with_metadata = (
         grouped_metadata_and_received_ips |
         'add received ip metadata: merge tags with answers' >> beam.
@@ -171,8 +171,8 @@ class MetadataAdder():
     # PCollection[Tuple[roundtrip_id, List[Tuple[roundtrip_id, SatelliteAnswerWithDateKey]]]]
     received_ips_grouped_by_roundtrip_ip = (
         received_ips_with_metadata |
-        'group received_by roundtrip: answer metadata' >>
-        beam.GroupBy(lambda x: x[0]).with_output_types(
+        'group received answers by roundtrip: answer metadata' >>
+        beam.GroupBy(lambda kv: kv[0]).with_output_types(
             Tuple[str, Iterable[Tuple[str, SatelliteAnswerWithDateKey]]]))
 
     grouped_rows_and_received_ips = (({

--- a/pipeline/metadata/ip_metadata_chooser.py
+++ b/pipeline/metadata/ip_metadata_chooser.py
@@ -4,7 +4,7 @@ import logging
 
 from pipeline.metadata import caida_ip_metadata
 from pipeline.metadata import dbip
-from pipeline.metadata.schema import IpMetadataWithKeys
+from pipeline.metadata.schema import IpMetadataWithDateKey
 
 
 # pylint: disable=too-many-instance-attributes
@@ -24,12 +24,12 @@ class IpMetadataChooser():
     self.caida = caida_db
     self.dbip = dbip_db
 
-  def get_metadata(self, ip: str) -> IpMetadataWithKeys:
+  def get_metadata(self, ip: str) -> IpMetadataWithDateKey:
     """Pick which metadata values to return for an IP from our sources."""
     try:
       (netblock, asn, as_name, as_full_name, as_type,
        country) = self.caida.lookup(ip)
-      metadata_values = IpMetadataWithKeys(
+      metadata_values = IpMetadataWithDateKey(
           ip=ip,
           date=self.date.isoformat(),
           netblock=netblock,
@@ -55,7 +55,7 @@ class IpMetadataChooser():
       #   metadata_values['country'] = country
     except KeyError as e:
       logging.warning('KeyError: %s\n', e)
-      metadata_values = IpMetadataWithKeys(ip=ip, date=self.date.isoformat())
+      metadata_values = IpMetadataWithDateKey(ip=ip, date=self.date.isoformat())
       # metadata values are missing, but entry should still exist
 
     return metadata_values

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -833,23 +833,23 @@ def process_satellite_lines(
   tagged_satellite = process_satellite_with_tags(row_lines, answer_lines,
                                                  resolver_lines)
 
-  # PCollection[BlockpageRow]
-  page_fetch_rows = process_satellite_page_fetches(page_fetch_lines)
-
-  # PCollection[SatelliteRow]
-  satellite_with_page_fetches = add_page_fetch_to_answers(
-      tagged_satellite, page_fetch_rows)
-
-  # PCollection[SatelliteRow]
-  post_processed_satellite = post_processing_satellite(
-      satellite_with_page_fetches)
-
   # PCollection[SatelliteRow]
   rows_with_resolver_ip_annotations = metadata_adder.annotate_row_ip(
-      post_processed_satellite)
+      tagged_satellite)
 
   # PCollection[SatelliteRow]
   rows_with_answer_ip_annotations = metadata_adder.annotate_answer_ips(
       rows_with_resolver_ip_annotations)
 
-  return rows_with_answer_ip_annotations
+  # PCollection[BlockpageRow]
+  page_fetch_rows = process_satellite_page_fetches(page_fetch_lines)
+
+  # PCollection[SatelliteRow]
+  satellite_with_page_fetches = add_page_fetch_to_answers(
+      rows_with_answer_ip_annotations, page_fetch_rows)
+
+  # PCollection[SatelliteRow]
+  post_processed_satellite = post_processing_satellite(
+      satellite_with_page_fetches)
+
+  return post_processed_satellite

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -13,7 +13,7 @@ import apache_beam as beam
 
 from pipeline.metadata import flatten_base
 from pipeline.metadata.beam_metadata import SourceDomainKey, SourceIpKey, DomainSourceIpKey, IP_METADATA_PCOLLECTION_NAME, ROWS_PCOLLECION_NAME, RECEIVED_IPS_PCOLLECTION_NAME, BLOCKPAGE_PCOLLECTION_NAME, make_source_ip_key, make_source_domain_key, make_domain_source_ip_key, merge_metadata_with_rows, merge_satellite_tags_with_answers, merge_tagged_answers_with_rows, merge_page_fetches_with_answers
-from pipeline.metadata.schema import SatelliteRow, SatelliteAnswer, SatelliteAnswerWithKeys, PageFetchRow, IpMetadata, IpMetadataWithKeys, MatchesControl, SCAN_TYPE_PAGE_FETCH
+from pipeline.metadata.schema import SatelliteRow, SatelliteAnswer, SatelliteAnswerWithSourceKey, PageFetchRow, IpMetadata, IpMetadataWithSourceKey, MatchesControl, SCAN_TYPE_PAGE_FETCH
 from pipeline.metadata.lookup_country_code import country_name_to_code
 from pipeline.metadata import flatten_satellite
 from pipeline.metadata import flatten
@@ -172,8 +172,8 @@ def _get_received_ips_with_roundtrip_id_and_source_domain(
     yield (key, (roundtrip_id, answer))
 
 
-def _read_satellite_resolver_tags(filepath: str,
-                                  line: str) -> Iterator[IpMetadataWithKeys]:
+def _read_satellite_resolver_tags(
+    filepath: str, line: str) -> Iterator[IpMetadataWithSourceKey]:
   """Read data for IP tagging from Satellite.
 
     Args:
@@ -181,7 +181,7 @@ def _read_satellite_resolver_tags(filepath: str,
       line: json str (dictionary containing geo tag data)
 
   Yields:
-      A IpMetadataWithKeys of the format
+      A IpMetadataWithSourceKey of the format
         IpMetadata(
           ip='1.1.1.1',
           source='CP_Satellite-2022-01-02-12-00-01'
@@ -198,7 +198,7 @@ def _read_satellite_resolver_tags(filepath: str,
 
   ip: str = scan.get('resolver') or scan.get('vp')
   source = flatten_base.source_from_filename(filepath)
-  tags = IpMetadataWithKeys(ip=ip, source=source)
+  tags = IpMetadataWithSourceKey(ip=ip, source=source)
 
   if 'name' in scan:
     tags.name = scan['name']
@@ -211,8 +211,8 @@ def _read_satellite_resolver_tags(filepath: str,
   yield tags
 
 
-def _read_satellite_answer_tags(filepath: str,
-                                line: str) -> Iterator[SatelliteAnswerWithKeys]:
+def _read_satellite_answer_tags(
+    filepath: str, line: str) -> Iterator[SatelliteAnswerWithSourceKey]:
   """Read data for IP tagging from Satellite.
 
     Args:
@@ -237,7 +237,7 @@ def _read_satellite_answer_tags(filepath: str,
                     line)
     return
 
-  answer_with_keys = SatelliteAnswerWithKeys(
+  answer_with_keys = SatelliteAnswerWithSourceKey(
       ip=scan['ip'],
       source=flatten_base.source_from_filename(filepath),
       http=scan['http'],
@@ -251,7 +251,7 @@ def _read_satellite_answer_tags(filepath: str,
 
 def _add_vantage_point_tags(
     rows: beam.pvalue.PCollection[SatelliteRow],
-    tags: beam.pvalue.PCollection[IpMetadataWithKeys]
+    tags: beam.pvalue.PCollection[IpMetadataWithSourceKey]
 ) -> beam.pvalue.PCollection[SatelliteRow]:
   """Add tags for vantage point IPs - resolver name (hostname/control/special) and country
 
@@ -262,12 +262,12 @@ def _add_vantage_point_tags(
     Returns:
       PCollection of measurement rows with tag information added to the ip row
   """
-  # PCollection[Tuple[SourceIpKey,IpMetadataWithKeys]]
+  # PCollection[Tuple[SourceIpKey,IpMetadataWithSourceKey]]
   ips_with_metadata = (
       tags | 'tags key by ips and source' >>
       beam.Map(lambda metadata:
                (make_source_ip_key(metadata), metadata)).with_output_types(
-                   Tuple[SourceIpKey, IpMetadataWithKeys]))
+                   Tuple[SourceIpKey, IpMetadataWithSourceKey]))
 
   # PCollection[Tuple[SourceIpKey,SatelliteRow]]
   rows_keyed_by_ip_and_source = (
@@ -275,7 +275,7 @@ def _add_vantage_point_tags(
       beam.Map(lambda row: (make_source_ip_key(row), row)).with_output_types(
           Tuple[SourceIpKey, SatelliteRow]))
 
-  # PCollection[Tuple[SourceIpKey,Dict[input_name_key,List[SatelliteRow|IpMetadataWithKeys]]]]
+  # PCollection[Tuple[SourceIpKey,Dict[input_name_key,List[SatelliteRow|IpMetadataWithSourceKey]]]]
   grouped_metadata_and_rows = (({
       IP_METADATA_PCOLLECTION_NAME: ips_with_metadata,
       ROWS_PCOLLECION_NAME: rows_keyed_by_ip_and_source
@@ -292,8 +292,8 @@ def _add_vantage_point_tags(
 
 def _add_satellite_tags(
     rows: beam.pvalue.PCollection[SatelliteRow],
-    resolver_tags: beam.pvalue.PCollection[IpMetadataWithKeys],
-    answer_tags: beam.pvalue.PCollection[SatelliteAnswerWithKeys]
+    resolver_tags: beam.pvalue.PCollection[IpMetadataWithSourceKey],
+    answer_tags: beam.pvalue.PCollection[SatelliteAnswerWithSourceKey]
 ) -> beam.pvalue.PCollection[SatelliteRow]:
   """Add tags for resolvers and answer IPs and unflatten the Satellite measurement rows.
 
@@ -454,7 +454,7 @@ def post_processing_satellite(
 
 def add_received_ip_tags(
     rows: beam.pvalue.PCollection[SatelliteRow],
-    tags: beam.pvalue.PCollection[SatelliteAnswerWithKeys]
+    tags: beam.pvalue.PCollection[SatelliteAnswerWithSourceKey]
 ) -> beam.pvalue.PCollection[SatelliteRow]:
   """Add ip metadata info to received ip lists in rows
 
@@ -498,11 +498,11 @@ def add_received_ip_tags(
       ]
     }
   """
-  # PCollection[Tuple[SourceIpKey, SatelliteAnswerWithKeys]]
+  # PCollection[Tuple[SourceIpKey, SatelliteAnswerWithSourceKey]]
   tags_keyed_by_ip_and_source = (
       tags | 'tags: key by ips and source' >>
       beam.Map(lambda tag: (make_source_ip_key(tag), tag)).with_output_types(
-          Tuple[SourceIpKey, SatelliteAnswerWithKeys]))
+          Tuple[SourceIpKey, SatelliteAnswerWithSourceKey]))
 
   # PCollection[Tuple[roundtrip_id, SatelliteRow]]
   rows_with_roundtrip_id = (
@@ -520,18 +520,18 @@ def add_received_ip_tags(
       RECEIVED_IPS_PCOLLECTION_NAME: received_ips_keyed_by_ip_and_source
   }) | 'add received ip tags: group by keys' >> beam.CoGroupByKey())
 
-  # PCollection[Tuple[roundtrip_id, SatelliteAnswerWithKeys]] received ip row with
+  # PCollection[Tuple[roundtrip_id, SatelliteAnswerWithSourceKey]] received ip row with
   received_ips_with_metadata = (
       grouped_metadata_and_received_ips |
       'add received ip tags: merge tags with answers' >>
       beam.FlatMapTuple(merge_satellite_tags_with_answers).with_output_types(
-          Tuple[str, SatelliteAnswerWithKeys]))
+          Tuple[str, SatelliteAnswerWithSourceKey]))
 
-  # PCollection[Tuple[roundtrip_id, List[Tuple[roundtrip_id, SatelliteAnswerWithKeys]]]]
+  # PCollection[Tuple[roundtrip_id, List[Tuple[roundtrip_id, SatelliteAnswerWithSourceKey]]]]
   received_ips_grouped_by_roundtrip_ip = (
       received_ips_with_metadata | 'group received_by roundtrip' >>
       beam.GroupBy(lambda x: x[0]).with_output_types(
-          Tuple[str, Iterable[Tuple[str, SatelliteAnswerWithKeys]]]))
+          Tuple[str, Iterable[Tuple[str, SatelliteAnswerWithSourceKey]]]))
 
   grouped_rows_and_received_ips = (({
       ROWS_PCOLLECION_NAME: rows_with_roundtrip_id,
@@ -567,16 +567,17 @@ def process_satellite_with_tags(
       row_lines | 'flatten json' >> beam.ParDo(
           flatten.FlattenMeasurement()).with_output_types(SatelliteRow))
 
-  # PCollection[IpMetadataWithKeys]
+  # PCollection[IpMetadataWithSourceKey]
   resolver_tags = (
-      resolver_lines | 'resolver tag rows' >> beam.FlatMapTuple(
-          _read_satellite_resolver_tags).with_output_types(IpMetadataWithKeys))
+      resolver_lines |
+      'resolver tag rows' >> beam.FlatMapTuple(_read_satellite_resolver_tags).
+      with_output_types(IpMetadataWithSourceKey))
 
-  # PCollection[SatelliteAnswerWithKeys]
+  # PCollection[SatelliteAnswerWithSourceKey]
   answer_tags = (
       answer_lines |
       'answer tag rows' >> beam.FlatMapTuple(_read_satellite_answer_tags).
-      with_output_types(SatelliteAnswerWithKeys))
+      with_output_types(SatelliteAnswerWithSourceKey))
 
   rows_with_metadata = _add_satellite_tags(rows, resolver_tags, answer_tags)
 
@@ -626,18 +627,18 @@ def add_page_fetch_to_answers(
   }) | 'cogroup answers and page fetches' >> beam.CoGroupByKey())
 
   # add page fetches into satellite answers
-  # PCollection[Tuple[roundtrip_id, SatelliteAnswerWithKeys]]
+  # PCollection[Tuple[roundtrip_id, SatelliteAnswerWithSourceKey]]
   received_ips_with_page_fetches = (
       grouped_page_fetches_and_answers |
       'add page fetches : merge page fetches with answers' >>
       beam.FlatMapTuple(merge_page_fetches_with_answers).with_output_types(
-          Tuple[str, SatelliteAnswerWithKeys]))
+          Tuple[str, SatelliteAnswerWithSourceKey]))
 
-  # PCollection[Tuple[roundtrip_id, List[Tuple[roundtrip_id, SatelliteAnswerWithKeys]]]]
+  # PCollection[Tuple[roundtrip_id, List[Tuple[roundtrip_id, SatelliteAnswerWithSourceKey]]]]
   received_ips_grouped_by_roundtrip_ip = (
       received_ips_with_page_fetches | 'group answers by roundtrip' >>
       beam.GroupBy(lambda x: x[0]).with_output_types(
-          Tuple[str, Iterable[Tuple[str, SatelliteAnswerWithKeys]]]))
+          Tuple[str, Iterable[Tuple[str, SatelliteAnswerWithSourceKey]]]))
 
   grouped_rows_and_received_ips = (({
       ROWS_PCOLLECION_NAME: rows_with_roundtrip_id,
@@ -847,4 +848,8 @@ def process_satellite_lines(
   rows_with_resolver_ip_annotations = metadata_adder.annotate_row_ip(
       post_processed_satellite)
 
-  return rows_with_resolver_ip_annotations
+  # PCollection[SatelliteRow]
+  rows_with_answer_ip_annotations = metadata_adder.annotate_answer_ips(
+      rows_with_resolver_ip_annotations)
+
+  return rows_with_answer_ip_annotations

--- a/pipeline/metadata/schema.py
+++ b/pipeline/metadata/schema.py
@@ -55,12 +55,19 @@ class IpMetadata():
 
 
 @dataclass
-class IpMetadataWithKeys(IpMetadata):
-  """Extension of IpMetadata with ip, date, and source keys."""
+class IpMetadataWithSourceKey(IpMetadata):
+  """Extension of IpMetadata with ip and source keys."""
+  # Keys
+  ip: str = ''
+  source: str = ''
+
+
+@dataclass
+class IpMetadataWithDateKey(IpMetadata):
+  """Extension of IpMetadata with ip and date keys."""
   # Keys
   ip: str = ''
   date: str = ''
-  source: str = ''
 
 
 def merge_ip_metadata(base: IpMetadata, new: IpMetadata) -> None:
@@ -111,13 +118,28 @@ class SatelliteAnswer():
 
 
 @dataclass
-class SatelliteAnswerWithKeys(SatelliteAnswer):
+class SatelliteAnswerWithSourceKey(SatelliteAnswer):
   """Satellite Answer Metadata.
 
   When this metadata is being passed around
   it needs an additional source field to keep track of when it's valid.
   """
   source: str = ''
+
+
+@dataclass
+class SatelliteAnswerWithDateKey(SatelliteAnswer):
+  """Satellite Answer Metadata.
+
+  When this metadata is being passed around
+  it needs an additional date field to keep track of when it's valid.
+  """
+  date: str = ''
+
+
+# Some operations can take either kind of key
+SatelliteAnswerWithAnyKey = Union[SatelliteAnswerWithSourceKey,
+                                  SatelliteAnswerWithDateKey]
 
 
 def merge_satellite_answers(base: SatelliteAnswer,

--- a/pipeline/metadata/test_add_metadata.py
+++ b/pipeline/metadata/test_add_metadata.py
@@ -8,7 +8,7 @@ import apache_beam as beam
 from apache_beam.testing.test_pipeline import TestPipeline
 import apache_beam.testing.util as beam_test_util
 
-from pipeline.metadata.schema import BigqueryRow, IpMetadata, IpMetadataWithKeys
+from pipeline.metadata.schema import BigqueryRow, IpMetadata, IpMetadataWithDateKey
 from pipeline.metadata.ip_metadata_chooser import FakeIpMetadataChooserFactory
 from pipeline.metadata import beam_metadata
 from pipeline.metadata.add_metadata import MetadataAdder
@@ -118,7 +118,7 @@ class MetadataAdderTest(unittest.TestCase):
     metadatas = list(adder._annotate_ips('2020-01-01', ['1.1.1.1', '8.8.8.8']))
 
     expected_key_1: beam_metadata.DateIpKey = ('2020-01-01', '1.1.1.1')
-    expected_value_1 = IpMetadataWithKeys(
+    expected_value_1 = IpMetadataWithDateKey(
         ip='1.1.1.1',
         date='2020-01-01',
         netblock='1.0.0.1/24',
@@ -131,7 +131,7 @@ class MetadataAdderTest(unittest.TestCase):
     )
 
     expected_key_2: beam_metadata.DateIpKey = ('2020-01-01', '8.8.8.8')
-    expected_value_2 = IpMetadataWithKeys(
+    expected_value_2 = IpMetadataWithDateKey(
         ip='8.8.8.8',
         date='2020-01-01',
         netblock='8.8.8.0/24',
@@ -156,7 +156,7 @@ class MetadataAdderTest(unittest.TestCase):
     # Test Maxmind lookup when country data is missing
     # Cloudflare IPs return Australia
     expected_key_1 = ('2020-01-01', '1.1.1.3')
-    expected_value_1 = IpMetadataWithKeys(
+    expected_value_1 = IpMetadataWithDateKey(
         ip='1.1.1.3',
         date='2020-01-01',
         netblock='1.0.0.1/24',

--- a/pipeline/metadata/test_beam_metadata.py
+++ b/pipeline/metadata/test_beam_metadata.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Union
 import unittest
 
 from pipeline.metadata import beam_metadata
-from pipeline.metadata.schema import BigqueryRow, IpMetadata, IpMetadataWithKeys
+from pipeline.metadata.schema import BigqueryRow, IpMetadata, IpMetadataWithDateKey
 
 
 class BeamMetadataTest(unittest.TestCase):
@@ -13,7 +13,7 @@ class BeamMetadataTest(unittest.TestCase):
   def test_merge_metadata_with_rows(self) -> None:
     """Test merging IP metadata pcollection with rows pcollection."""
     key: beam_metadata.DateIpKey = ('2020-01-01', '1.1.1.1')
-    ip_metadata = IpMetadataWithKeys(
+    ip_metadata = IpMetadataWithDateKey(
         ip='1.1.1.1',
         date='2020-01-01',
         netblock='1.0.0.1/24',
@@ -35,7 +35,7 @@ class BeamMetadataTest(unittest.TestCase):
             date='2020-01-01',
         )
     ]
-    value: Dict[str, Union[List[BigqueryRow], List[IpMetadataWithKeys]]] = {
+    value: Dict[str, Union[List[BigqueryRow], List[IpMetadataWithDateKey]]] = {
         beam_metadata.IP_METADATA_PCOLLECTION_NAME: [ip_metadata],
         beam_metadata.ROWS_PCOLLECION_NAME: rows
     }

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -7,7 +7,7 @@ import apache_beam as beam
 from apache_beam.testing.test_pipeline import TestPipeline
 import apache_beam.testing.util as beam_test_util
 
-from pipeline.metadata.schema import SatelliteRow, PageFetchRow, HttpsResponse, SatelliteAnswer, SatelliteAnswerWithKeys, IpMetadataWithKeys, IpMetadata, MatchesControl
+from pipeline.metadata.schema import SatelliteRow, PageFetchRow, HttpsResponse, SatelliteAnswer, SatelliteAnswerWithSourceKey, IpMetadata, IpMetadataWithSourceKey, MatchesControl
 from pipeline.metadata import satellite
 
 # pylint: disable=too-many-lines
@@ -19,7 +19,7 @@ class SatelliteTest(unittest.TestCase):
   # pylint: disable=protected-access
 
   def test_make_source_ip_key(self) -> None:
-    row = IpMetadataWithKeys(
+    row = IpMetadataWithSourceKey(
         source='CP_Satellite-2020-12-17-12-00-01',
         ip='1.2.3.4',
     )
@@ -45,12 +45,12 @@ class SatelliteTest(unittest.TestCase):
 
     data = zip(filenames, lines)
 
-    tag1 = IpMetadataWithKeys(
+    tag1 = IpMetadataWithSourceKey(
         ip='1.1.1.1',
         source='CP_Satellite-2020-12-17-12-00-01',
         country='US'
     )
-    tag2 = IpMetadataWithKeys(
+    tag2 = IpMetadataWithSourceKey(
         ip='1.1.1.3',
         source='CP_Satellite-2020-12-17-12-00-01',
         country='AU'
@@ -89,7 +89,7 @@ class SatelliteTest(unittest.TestCase):
 
     data = zip(filenames, lines)
 
-    tag1 = SatelliteAnswerWithKeys(
+    tag1 = SatelliteAnswerWithSourceKey(
         ip='60.210.17.137',
         source='CP_Satellite-2020-12-17-12-00-01',
         cert='a2fed117238c94a04ba787cfe69e93de36cc8571bab44d5481df9becb9beec75',


### PR DESCRIPTION
The main point of this is `annotate_answer_ips` which performs another triple cogroup to overwrite the satellite answer ip metadata with data from routeviews.

- Refactoring some of the `*WithKey` types in `schema.py` to be clearer about when we're using date vs source keys.
- Moved adding page fetch info as late as possible in the satellite pipeline to speed up processing since page fetches are huge.
- Fixed beam pipeline tests in `test_add_metadata.py` which were broken.
- Similar to [PR138](https://github.com/censoredplanet/censoredplanet-analysis/pull/138) this does the triple cogroup independently. This means we now have three independent triple cogroups (adding satellite tags, routeview metadata, and page fetches) which we should eventually refactor to share work. That will speed up the pipeline at the cost of code readability.

Currently running a [test backfill](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-05-20_04_57_32-4516889685021138454?project=firehook-censoredplanet)