### PR TITLE
catch bad ip parse and add tests

### DIFF
--- a/pipeline/metadata/caida_ip_metadata.py
+++ b/pipeline/metadata/caida_ip_metadata.py
@@ -231,7 +231,11 @@ class CaidaIpMetadata():
     Raises:
       KeyError: when the IP's ASN can't be found
     """
-    asn, netblock = self.asn_db.lookup(ip)
+    try:
+      asn, netblock = self.asn_db.lookup(ip)
+    except ValueError as ex:
+      raise KeyError(
+          f"Could not parse IP {ip} at {self.date.isoformat()}. {ex}") from ex
 
     if not asn:
       raise KeyError(f"Missing IP {ip} at {self.date.isoformat()}")


### PR DESCRIPTION
This fixes a [new error](https://console.cloud.google.com/errors/detail/CPvk-Zvf6MaYHA;time=P30D?project=firehook-censoredplanet&utm_source=error-reporting-notification&utm_medium=email&utm_content=new-error) I was seeing when trying to backfill https://github.com/censoredplanet/censoredplanet-analysis/pull/163

`ValueError: inet_pton(v4) returned error [while running 'get ip metadata for answers']`

This is coming from the fact that satellite answer ips can apparently have arbitrary data, some of which is not valid ips. We were never seeing this before since we've only been parsing ips preselected by censored planet.

I've also added some more tests-as-documentation to the E2E tests, covering the existing behavior for all our ip metadata sources for ipv6 and invalid ips.

I'm currently running a [test backfill](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-05-20_04_57_32-4516889685021138454?project=firehook-censoredplanet) of https://github.com/censoredplanet/censoredplanet-analysis/pull/163 + this fix