### PR TITLE
Added new control domains for satellite

### DIFF
--- a/pipeline/metadata/flatten_base.py
+++ b/pipeline/metadata/flatten_base.py
@@ -23,7 +23,7 @@ CONTROL_URLS = [
     'a.root-servers.net',  # Satellite
     'www.example.com',  # Satellite
     'gstatic.com',  # Satellite
-    '1. yr-in-f94.1e100.net',  # Satellite - gstatic
+    'yr-in-f94.1e100.net',  # Satellite - gstatic
     'captive.apple.com',  # Satellite
     'usmia1-vip-bx-006.aaplimg.com',  # Satellite - captive.apple
     'cse.engin.umich.edu',  # Satellite

--- a/pipeline/metadata/flatten_base.py
+++ b/pipeline/metadata/flatten_base.py
@@ -23,7 +23,11 @@ CONTROL_URLS = [
     'a.root-servers.net',  # Satellite
     'www.example.com',  # Satellite
     'gstatic.com',  # Satellite
+    '1. yr-in-f94.1e100.net',  # Satellite - gstatic
     'captive.apple.com',  # Satellite
+    'usmia1-vip-bx-006.aaplimg.com',  # Satellite - captive.apple
+    'cse.engin.umich.edu',  # Satellite
+    'eecs.umich.edu',  # Satellite
 ]
 
 

--- a/pipeline/metadata/flatten_base.py
+++ b/pipeline/metadata/flatten_base.py
@@ -22,8 +22,8 @@ CONTROL_URLS = [
     'rtyutgyhefdafioasfjhjhi.com',  # HTTP/S
     'a.root-servers.net',  # Satellite
     'www.example.com',  # Satellite
-    'yr-in-f94.1e100.net',  # Satellite - gstatic
-    'usmia1-vip-bx-006.aaplimg.com',  # Satellite - captive.apple.com
+    'gstatic.com',  # Satellite
+    'captive.apple.com',  # Satellite
 ]
 
 

--- a/pipeline/metadata/flatten_base.py
+++ b/pipeline/metadata/flatten_base.py
@@ -21,7 +21,9 @@ CONTROL_URLS = [
     'example5718349450314.com',  # echo/discard
     'rtyutgyhefdafioasfjhjhi.com',  # HTTP/S
     'a.root-servers.net',  # Satellite
-    'www.example.com'  # Satellite
+    'www.example.com',  # Satellite
+    'yr-in-f94.1e100.net',  # Satellite - gstatic
+    'usmia1-vip-bx-006.aaplimg.com',  # Satellite - captive.apple.com
 ]
 
 


### PR DESCRIPTION
Added 2 new control domains for Satellite from [PR127](https://github.com/censoredplanet/satellitev2/pull/127/files):
1. [yr-in-f94.1e100.net](https://dnslytics.com/ip/74.125.136.94) - connectivitycheck.gstatic.com
2. usmia1-vip-bx-006.aaplimg.com - captive.apple.com

(These two control domains are experimental and might be removed latter)
