### PR TITLE
enable dataflow prime

### DIFF
--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -522,6 +522,7 @@ class ScanDataBeamPipelineRunner():
             'enable_execution_details_collection',
             'use_monitoring_state_manager'
         ],
+        dataflow_service_options=['enable_prime'],
         setup_file='./pipeline/setup.py')
     pipeline_options.view_as(SetupOptions).save_main_session = True
     return pipeline_options


### PR DESCRIPTION
https://cloud.google.com/dataflow/docs/guides/enable-dataflow-prime 

This seems to resolve the OOM issue. Presumably the vertical memory autoscaling is what's helping here.

Saw this succeed on a sat backfill from 2018-2021 data: [job](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-08-30_06_11_25-1234624000485466246;mainTab=JOB_METRICS?project=firehook-censoredplanet&pageState=(%22dfTime%22:(%22d%22:%22P1D%22)))

Job run over all the data failed, but only on the cogroup-answers-and-page-fetches part, so at least it's not a mystery regression, but more likely a change caused by all the new page fetches we're doing: [job](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-08-31_03_21_42-17969262743725370238?project=firehook-censoredplanet)