### PR TITLE
fix new lint error

### DIFF
--- a/mirror/internal/sync.py
+++ b/mirror/internal/sync.py
@@ -77,7 +77,7 @@ class RepositoryMirror():
       headers['If-None-Match'] = etag
 
     # Download file
-    req = requests.get(url, headers=headers, stream=True)
+    req = requests.get(url, headers=headers, stream=True, timeout=60)
 
     if req.status_code == 200:
       print("Status 200: Downloading...")

--- a/pipeline/metadata/test_blockpage.py
+++ b/pipeline/metadata/test_blockpage.py
@@ -202,7 +202,7 @@ class BlockpageTest(unittest.TestCase):
         matcher.match_page(content)
       end = time.perf_counter()
 
-      self.assertLess(end - start, 10)
+      self.assertLess(end - start, 15)
 
   def test_long_blockpage(self) -> None:
     # This blockpage is a random long page take from the data.


### PR DESCRIPTION
error: https://github.com/censoredplanet/censoredplanet-analysis/runs/8110485361?check_suite_focus=true

I also bumped up the time limit for the blockpage performance test. It's been failing occasionally since we added a bunch of new blockpage signatures.