### PR TITLE
reshuffle lines after reading in to avoid fusion

### DIFF
--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -146,7 +146,12 @@ def _read_scan_text(
   lines = (
       pfilenames | "read files" >> beam.io.ReadAllFromText(with_filename=True))
 
-  return lines
+  # Shuffle to avoid fusion of largest files
+  # PCollection[Tuple(filename, line)]
+  shuffled_lines = (
+      lines | 'reshuffle lines' >> beam.transforms.util.Reshuffle())
+
+  return shuffled_lines
 
 
 def _between_dates(filename: str,


### PR DESCRIPTION
Based on [this](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-09-05_22_04_34-12568811080369607834;mainTab=RECOMMENDATIONS?project=firehook-censoredplanet) dataflow insight with [this solution](https://cloud.google.com/dataflow/docs/guides/using-dataflow-insights?&_ga=2.169271073.-187281087.1661514518#high-fan-out):

> A fusion break can be inserted after the following transforms to increase parallelism: read files/ReadAllFiles/ReadRange. The transforms had the following output-to-input element count ratio, respectively: 90662.