### PR TITLE
parse and pipe through new resolver profile fields

### DIFF
--- a/pipeline/e2e_test_data/Satellitev2-2021-10-20/resolvers_profile.json
+++ b/pipeline/e2e_test_data/Satellitev2-2021-10-20/resolvers_profile.json
@@ -1,0 +1,2 @@
+{"resolver": "208.67.222.123", "non_zero_rcode": "0.1290", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.0000"}
+{"resolver": "114.141.52.91", "non_zero_rcode": "0.0209", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0005", "invalid_cert": "0.0000"}

--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -117,6 +117,7 @@ def local_data_to_load_satellite_v2(*_: List[Any]) -> List[str]:
       'pipeline/e2e_test_data/Satellitev2_2021-04-25/results.json',
       'pipeline/e2e_test_data/Satellitev2-2021-10-20/blockpages.json',
       'pipeline/e2e_test_data/Satellitev2-2021-10-20/resolvers.json',
+      'pipeline/e2e_test_data/Satellitev2-2021-10-20/resolvers_profile.json',
       'pipeline/e2e_test_data/Satellitev2-2021-10-20/results.json',
   ]
 

--- a/pipeline/metadata/satellite.py
+++ b/pipeline/metadata/satellite.py
@@ -21,6 +21,7 @@ from pipeline.metadata.add_metadata import MetadataAdder
 
 # Data files for the Satellite pipeline
 SATELLITE_RESOLVERS_FILE = 'resolvers.json'  #v1, v2.2
+SATELLITE_RESOLVERS_PROFILE_FILE = 'resolvers_profile.json'  #v2.3
 
 SATELLITE_RESULTS_FILE = 'results.json'  # v2.1, v2.2
 
@@ -37,7 +38,8 @@ SATELLITE_BLOCKPAGES_FILE = 'blockpages.json'  # v2.2
 
 # Files containing metadata for satellite DNS resolvers
 SATELLITE_RESOLVER_TAG_FILES = [
-    SATELLITE_RESOLVERS_FILE, SATELLITE_TAGGED_RESOLVERS_FILE
+    SATELLITE_RESOLVERS_FILE, SATELLITE_TAGGED_RESOLVERS_FILE,
+    SATELLITE_RESOLVERS_PROFILE_FILE
 ]
 
 # Files containing metadata for satellite receives answer ips
@@ -187,6 +189,7 @@ def _read_satellite_resolver_tags(
           source='CP_Satellite-2022-01-02-12-00-01'
           country='US'  # optional
           name='one.one.one.one'  # optional
+          non_zero_rcode_rate = .5  # optional
         )
   """
   try:
@@ -200,6 +203,7 @@ def _read_satellite_resolver_tags(
   source = flatten_base.source_from_filename(filepath)
   tags = IpMetadataWithSourceKey(ip=ip, source=source)
 
+  # Fields in SATELLITE_RESOLVERS_FILE
   if 'name' in scan:
     tags.name = scan['name']
 
@@ -207,6 +211,19 @@ def _read_satellite_resolver_tags(
     tags.country = scan['location']['country_code']
   if 'country' in scan:
     tags.country = country_name_to_code(scan['country'])
+
+  # Fields in SATELLITE_RESOLVERS_PROFILE_FILE
+  # which contain aggregate rates 0-1 of test failures on that resolver
+  if 'non_zero_rcode' in scan:
+    tags.non_zero_rcode_rate = float(scan['non_zero_rcode'])
+  if 'private_ip' in scan:
+    tags.private_ip_rate = float(scan['private_ip'])
+  if 'zero_ip' in scan:
+    tags.zero_ip_rate = float(scan['zero_ip'])
+  if 'connect_error' in scan:
+    tags.connect_error_rate = float(scan['connect_error'])
+  if 'invalid_cert' in scan:
+    tags.invalid_cert_rate = float(scan['invalid_cert'])
 
   yield tags
 

--- a/pipeline/metadata/schema.py
+++ b/pipeline/metadata/schema.py
@@ -55,6 +55,12 @@ class IpMetadata():
   organization: Optional[str] = None
   # Satellite Metadata
   name: Optional[str] = None
+  # Satellite metadata related to resolver aggregate statistics
+  non_zero_rcode_rate: Optional[float] = None
+  private_ip_rate: Optional[float] = None
+  zero_ip_rate: Optional[float] = None
+  connect_error_rate: Optional[float] = None
+  invalid_cert_rate: Optional[float] = None
 
 
 @dataclass
@@ -75,6 +81,7 @@ class IpMetadataWithDateKey(IpMetadata):
 
 def merge_ip_metadata(base: IpMetadata, new: IpMetadata) -> None:
   """Merge metadata info into an existing metadata."""
+  # pylint: disable=too-many-branches
   if new.netblock is not None:
     base.netblock = new.netblock
   if new.asn is not None:
@@ -89,8 +96,20 @@ def merge_ip_metadata(base: IpMetadata, new: IpMetadata) -> None:
     base.country = new.country
   if new.organization is not None:
     base.organization = new.organization
+  # Satellite resolver metadata
   if new.name is not None:
     base.name = new.name
+  if new.non_zero_rcode_rate is not None:
+    base.non_zero_rcode_rate = new.non_zero_rcode_rate
+  if new.private_ip_rate is not None:
+    base.private_ip_rate = new.private_ip_rate
+  if new.zero_ip_rate is not None:
+    base.zero_ip_rate = new.zero_ip_rate
+  if new.connect_error_rate is not None:
+    base.connect_error_rate = new.connect_error_rate
+  if new.invalid_cert_rate is not None:
+    base.invalid_cert_rate = new.invalid_cert_rate
+  # pylint: enable=too-many-branches
 
 
 @dataclass
@@ -298,6 +317,11 @@ def flatten_to_dict_satellite(row: SatelliteRow) -> Dict[str, Any]:
       'resolver_as_class': row.ip_metadata.as_class,
       'resolver_country': row.ip_metadata.country,
       'resolver_organization': row.ip_metadata.organization,
+      'resolver_non_zero_rcode_rate': row.ip_metadata.non_zero_rcode_rate,
+      'resolver_private_ip_rate': row.ip_metadata.private_ip_rate,
+      'resolver_zero_ip_rate': row.ip_metadata.zero_ip_rate,
+      'resolver_connect_error_rate': row.ip_metadata.connect_error_rate,
+      'resolver_invalid_cert_rate': row.ip_metadata.invalid_cert_rate,
       'received_error': row.error,
       'received_rcode': row.rcode,
       'answers': [],
@@ -398,6 +422,11 @@ def dict_to_gcs_dict_satellite(
   measurement_dict.pop('excluded')
   measurement_dict.pop('exclude_reason')
   measurement_dict.pop('has_type_a')
+  measurement_dict.pop('resolver_non_zero_rcode_rate')
+  measurement_dict.pop('resolver_private_ip_rate')
+  measurement_dict.pop('resolver_zero_ip_rate')
+  measurement_dict.pop('resolver_connect_error_rate')
+  measurement_dict.pop('resolver_invalid_cert_rate')
   for i in range(0, len(measurement_dict['answers'])):
     measurement_dict['answers'][i].pop('matches_control')
     measurement_dict['answers'][i].pop('match_confidence', None)
@@ -489,6 +518,12 @@ SATELLITE_BIGQUERY_SCHEMA = {
     'resolver_country': ('string', 'nullable'),
     # Columns from DBIP
     'resolver_organization': ('string', 'nullable'),
+    # Columns from resolver profile
+    'resolver_non_zero_rcode_rate': ('float', 'nullable'),
+    'resolver_private_ip_rate': ('float', 'nullable'),
+    'resolver_zero_ip_rate': ('float', 'nullable'),
+    'resolver_connect_error_rate': ('float', 'nullable'),
+    'resolver_invalid_cert_rate': ('float', 'nullable'),
 
     # Observation
     'received_error': ('string', 'nullable'),

--- a/pipeline/metadata/test_satellite.py
+++ b/pipeline/metadata/test_satellite.py
@@ -50,16 +50,26 @@ class SatelliteTest(unittest.TestCase):
     """Test reading rows from Satellite resolver tag files."""
     tagged_resolver1 = {'resolver': '1.1.1.1', 'country': 'United States'}
     tagged_resolver2 = {'resolver': '1.1.1.3', 'country': 'Australia'}
+    resolver_profile = {
+        'resolver': '182.76.93.77',
+        'non_zero_rcode': '0.1290',
+        'private_ip': '0.0000',
+        'zero_ip': '0.0000',
+        'connect_error': '0.0000',
+        'invalid_cert': '0.0000'
+    }
     # yapf: disable
 
     lines = [
         json.dumps(tagged_resolver1),
         json.dumps(tagged_resolver2),
+        json.dumps(resolver_profile),
     ]
 
     filenames = [
       "CP_Satellite-2020-12-17-12-00-01/resolvers.json",
       "CP_Satellite-2020-12-17-12-00-01/resolvers.json.gz",
+      "CP_Satellite-2022-10-26-00-01-01/resolvers_profile.json.gz",
     ]
 
     data = zip(filenames, lines)
@@ -74,9 +84,18 @@ class SatelliteTest(unittest.TestCase):
         source='CP_Satellite-2020-12-17-12-00-01',
         country='AU'
     )
+    tag3 = IpMetadataWithSourceKey(
+        ip='182.76.93.77',
+        source='CP_Satellite-2022-10-26-00-01-01',
+        non_zero_rcode_rate=0.1290,
+        private_ip_rate=0,
+        zero_ip_rate=0,
+        connect_error_rate=0,
+        invalid_cert_rate=0
+    )
     # yapf: enable
 
-    expected_resolver_tags = [tag1, tag2]
+    expected_resolver_tags = [tag1, tag2, tag3]
 
     with TestPipeline() as p:
       lines = p | 'create tags' >> beam.Create(data)
@@ -1022,6 +1041,7 @@ class SatelliteTest(unittest.TestCase):
         "CP_Satellite-2021-10-20-12-00-01/resolvers.json",
         "CP_Satellite-2021-10-20-12-00-01/resolvers.json",
         "CP_Satellite-2021-10-20-12-00-01/resolvers.json",
+        "CP_Satellite-2021-10-20-12-00-01/resolvers_profile.json"
     ]
 
     # yapf: disable
@@ -1034,7 +1054,13 @@ class SatelliteTest(unittest.TestCase):
          "location": {"country_name": "United States","country_code": "US"}},
         {"vp": "62.80.182.26",
          "name": "mx4.orlantrans.com.",
-         "location": {"country_name": "Ukraine","country_code": "UA"}}
+         "location": {"country_name": "Ukraine","country_code": "UA"}},
+        {"resolver": "208.67.220.220",
+         "non_zero_rcode": "0.1290",
+         "private_ip": "0.0000",
+         "zero_ip": "0.0000",
+         "connect_error": "0.0000",
+         "invalid_cert": "0.0000"}
     ]
     # yapf: enable
 
@@ -1098,6 +1124,11 @@ class SatelliteTest(unittest.TestCase):
         ip_metadata = IpMetadata(
             country = 'US',
             name = 'resolver2.opendns.com.',
+            non_zero_rcode_rate = 0.129,
+            private_ip_rate = 0,
+            zero_ip_rate = 0,
+            connect_error_rate = 0,
+            invalid_cert_rate = 0,
         )
     ), SatelliteRow(
         received = [],
@@ -1225,6 +1256,8 @@ class SatelliteTest(unittest.TestCase):
          "resolver_tag"),
         ("CP_Satellite-2020-09-02-12-00-01/tagged_resolvers.json",
          "resolver_tag"),
+        ("CP_Satellite-2020-09-02-12-00-01/resolvers_profile.json",
+         "resolver_tag"),
         ("CP_Satellite-2020-09-02-12-00-01/tagged_answers.json", "answer_tag"),
         ("CP_Satellite-2020-09-02-12-00-01/tagged_answers.json", "answer_tag"),
         ("CP_Satellite-2021-09-02-12-00-01/blockpages.json", "blockpage"),
@@ -1232,10 +1265,10 @@ class SatelliteTest(unittest.TestCase):
         ("CP_Satellite-2020-09-02-12-00-01/interference.json", "row")
     ]
 
-    expected_resolver_tags = data[0:4]
-    expected_answer_tags = data[4:6]
-    expected_blockpages = data[6:7]
-    expected_rows = data[7:]
+    expected_resolver_tags = data[0:5]
+    expected_answer_tags = data[5:7]
+    expected_blockpages = data[7:8]
+    expected_rows = data[8:]
 
     with TestPipeline() as p:
       lines = p | 'create data' >> beam.Create(data)

--- a/pipeline/metadata/test_schema.py
+++ b/pipeline/metadata/test_schema.py
@@ -140,7 +140,12 @@ class SchemaTest(unittest.TestCase):
           as_name = 'CLOUDFLARENET',
           as_full_name = 'Cloudflare Inc.',
           as_class = 'Content',
-          organization = 'Fake Organization'
+          organization = 'Fake Organization',
+          non_zero_rcode_rate = 0.129,
+          private_ip_rate = 0,
+          zero_ip_rate = 0,
+          connect_error_rate = 0,
+          invalid_cert_rate = 0
         ),
         received = [
           schema.SatelliteAnswer(
@@ -319,7 +324,12 @@ class SchemaTest(unittest.TestCase):
           as_name = 'CLOUDFLARENET',
           as_full_name = 'Cloudflare Inc.',
           as_class = 'Content',
-          organization = 'Fake Organization'
+          organization = 'Fake Organization',
+          non_zero_rcode_rate = 0.129,
+          private_ip_rate = 0,
+          zero_ip_rate = 0,
+          connect_error_rate = 0,
+          invalid_cert_rate = 0
         ),
         received = [
           schema.SatelliteAnswer(


### PR DESCRIPTION
We're not implementing any logic on these fields currently. Just passing them through to allow filtering on them in the query.

tested=ran e2e test

currently testing a [backfill](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-11-04_05_12_05-791960186426524064?project=firehook-censoredplanet)