### PR TITLE
add emoji to hyperquack outcomes

### DIFF
--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -14,7 +14,8 @@
 
 CREATE TEMP FUNCTION AddOutcomeEmoji(outcome STRING) AS (
   CASE
-    WHEN STARTS_WITH(outcome, "setup/") THEN outcome
+    WHEN STARTS_WITH(outcome, "setup/") THEN CONCAT("❔", outcome)
+    WHEN STARTS_WITH(outcome, "unknown/") THEN CONCAT("❔", outcome)
     WHEN STARTS_WITH(outcome, "expected/") THEN CONCAT("✅", SUBSTR(outcome, 10))
     ELSE CONCAT("❗️", outcome)
   END
@@ -66,7 +67,7 @@ WITH AllScans AS (
     WHERE NOT controls_failed
     GROUP BY date, source, country_code, network, outcome, domain, category, subnetwork
     # Filter it here so that we don't need to load the outcome to apply the report filtering on every filter.
-    HAVING NOT STARTS_WITH(outcome, "setup/")
+    HAVING NOT STARTS_WITH(outcome, "❔setup/")
 )
 SELECT
     Grouped.* EXCEPT (country_code),
@@ -75,7 +76,6 @@ SELECT
         WHEN (STARTS_WITH(outcome, "✅")) THEN 0
         WHEN (STARTS_WITH(outcome, "❗️")) THEN count
         WHEN (STARTS_WITH(outcome, "❔")) THEN NULL
-        ELSE count / 2.0  # unknown
     END AS unexpected_count
     FROM Grouped
     LEFT JOIN `firehook-censoredplanet.metadata.country_names` USING (country_code)

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -73,9 +73,9 @@ SELECT
     IFNULL(country_name, country_code) AS country_name,
     CASE
         WHEN (STARTS_WITH(outcome, "✅")) THEN 0
-        WHEN (STARTS_WITH(outcome, "❗️dial/") OR STARTS_WITH(outcome, "setup/") OR ENDS_WITH(outcome, "/invalid")) THEN NULL
-        WHEN (ENDS_WITH(outcome, "unknown")) THEN count / 2.0
-        ELSE count
+        WHEN (STARTS_WITH(outcome, "❗️")) THEN count
+        WHEN (STARTS_WITH(outcome, "❔")) THEN NULL
+        ELSE count / 2.0  # unknown
     END AS unexpected_count
     FROM Grouped
     LEFT JOIN `firehook-censoredplanet.metadata.country_names` USING (country_code)


### PR DESCRIPTION
Side dashboard with the emojified outcomes: [here](https://datastudio.google.com/c/reporting/40dc493c-9974-415c-93ec-bab04de93b6d/page/T33gB)

![image](https://user-images.githubusercontent.com/1127209/200036315-f89cb4ce-aeab-48c8-b188-bc011589c796.png)
