### PR TITLE
filter bad resolvers

### DIFF
--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -79,7 +79,9 @@ CREATE TEMP FUNCTION AnswersSignature(answers ANY TYPE) AS (
 #  /total_number_of_unique_domains_on_resolver_per_scan
 # resolvers which consistantly return too many errors are filtered out.
 CREATE TEMP FUNCTION BadResolver(
+  # Error rate in creating the DNS connection, including timeouts
   resolver_connect_error_rate FLOAT64,
+  # Failure to get a valid certificate when fetching the page from a returned IP.
   resolver_invalid_cert_rate FLOAT64,
   resolver_non_zero_rcode_rate FLOAT64
 ) AS (


### PR DESCRIPTION
Roughly filter DNS resolvers that aren't reliable because they have too many errors.

Dashboards: [1](https://datastudio.google.com/c/u/0/reporting/bcba5de4-0402-4687-8b7c-1ad1b04ad3d1/page/p_0foeibtt0c), [2](https://datastudio.google.com/c/reporting/fa204158-932b-43bf-b3e8-b346c1468792/page/p_mekso35lrc)

This is better than the [previous filtering solution](https://github.com/censoredplanet/censoredplanet-analysis/commit/4a28e74bf2aa13cdacba48523de7500c46207661) which was just a hacky query.