### PR TITLE
split out prod and dev projects

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -46,13 +46,13 @@ if [[ "${action}" == "backfill" ]]; then
     --iam-account ${service_account_id}-compute@developer.gserviceaccount.com
   fi
 
-  # --entrypoint 'python3 -m pipeline.run_beam_tables --env=prod --full'
+  # --entrypoint 'python3 -m pipeline.run_beam_tables --env=dev --full'
   docker run -it \
   -v $HOME/.config/gcloud:$HOME/.config/gcloud \
   -e GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/${service_account_id}_compute_credentials.json \
   ${project}
 
-elif [[ "${action}" == "prod" ]]; then
+elif [[ "${action}" == "dev" ]]; then
   # For builders outside the VPC security perimeter the build will succeed
   # but throw a logging error, so we ignore errors here
   gcloud builds submit . --tag gcr.io/${project}/pipeline --project ${project} || true

--- a/docs/production.md
+++ b/docs/production.md
@@ -1,8 +1,10 @@
 # Production
 
+:warning: This code is in the process of splitting up prod and dev.
+
 ## Running the Automated Pipeline
 
-There are two main top-level pieces of the production pipeline
+There are two main top-level pieces of the pipeline
 
  `python -m mirror.data_transfer`
 
@@ -15,7 +17,7 @@ This does some additional daily data processing and schedules a daily
 incremental Apache Beam pipeline over the data. It expects to be run via a
 Docker container on a GCE machine.
 
- `./deploy.sh prod`
+ `./deploy.sh dev`
 
 Will deploy the main pipeline loop to a GCE machine. If the machine does not
 exist it will be created, if it does exist it will be updated.
@@ -63,12 +65,12 @@ updated resources can then be committed and deployed.
 
 ### Processing Data
 
- `python -m pipeline.run_beam_tables --env=prod --full`
+ `python -m pipeline.run_beam_tables --env=dev --full`
 
 Runs the full Apache Beam pipeline. This will re-process all data and rebuild
 existing base tables.
 
- `python -m pipeline.run_beam_tables --env=prod`
+ `python -m pipeline.run_beam_tables --env=dev`
 
 Runs an appending Apache Beam pipeline. This will check for new unprocessed
 data, and process and append it to the base tables if they exist.
@@ -89,12 +91,12 @@ Here are the steps to run a backfill:
 *    Checkout master and make sure you're synced to the latest changes.
 *    `./deploy.sh delete` turn off the nightly pipeline so it doesn't conflict
      with the backfill
-*    `python -m pipeline.run_beam_tables --env=prod --scan_type=all --full` to
+*    `python -m pipeline.run_beam_tables --env=dev --scan_type=all --full` to
      run manual backfill jobs, this can take several hours.
 *    Make sure a job is running for each scan type in dataflow. If some scan
      types didn't take then re-run them by hand.
 *    Check if the backfill worked the next day
-*    if so run `./deploy.sh prod` at head to turn the pipeline back on with
+*    if so run `./deploy.sh dev` at head to turn the pipeline back on with
      the new code
 
 ## Access

--- a/firehook_resources.py
+++ b/firehook_resources.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 """Various cross-file constants and project-specific initializers."""
 
-PROJECT_NAME = 'firehook-censoredplanet'
+PROD_PROJECT_NAME = 'censoredplanet-analysisv1'
+DEV_PROJECT_NAME = 'firehook-censoredplanet'
 
 # Buckets that store scanfiles
 U_MICH_BUCKET = 'censoredplanetscanspublic'

--- a/mirror/data_transfer.py
+++ b/mirror/data_transfer.py
@@ -90,7 +90,7 @@ def setup_transfer_service(project_name: str, source_bucket: str,
 
 def setup_firehook_data_transfer() -> None:
   transfer_job_start = datetime.date.today()
-  setup_transfer_service(firehook_resources.PROJECT_NAME,
+  setup_transfer_service(firehook_resources.DEV_PROJECT_NAME,
                          firehook_resources.U_MICH_BUCKET,
                          firehook_resources.TARRED_BUCKET, transfer_job_start)
 

--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -40,8 +40,8 @@ from pipeline.metadata import sink
 
 # Tables have names like 'echo_scan' and 'http_scan
 BASE_TABLE_NAME = 'scan'
-# Prod data goes in the `firehook-censoredplanet:base' dataset
-PROD_DATASET_NAME = 'base'
+# Prod and dev data goes in the `firehook-censoredplanet:base' dataset
+BASE_DATASET_NAME = 'base'
 
 # Mapping of each scan type to the zone to run its pipeline in.
 # This adds more parallelization when running all pipelines.

--- a/pipeline/test_run_beam_tables.py
+++ b/pipeline/test_run_beam_tables.py
@@ -83,8 +83,8 @@ class RunBeamTablesTest(unittest.TestCase):
     """Test arg parsing for prod pipelines."""
     mock_runner = MagicMock(beam_tables.ScanDataBeamPipelineRunner)
 
-    with patch('pipeline.run_beam_tables.get_firehook_beam_pipeline_runner',
-               lambda: mock_runner):
+    with patch('pipeline.run_beam_tables.get_beam_pipeline_runner',
+               lambda _: mock_runner):
       args = argparse.Namespace(
           full=False,
           scan_type='all',
@@ -137,8 +137,8 @@ class RunBeamTablesTest(unittest.TestCase):
     """Test arg parsing for a user pipeline with dates."""
     mock_runner = MagicMock(beam_tables.ScanDataBeamPipelineRunner)
 
-    with patch('pipeline.run_beam_tables.get_firehook_beam_pipeline_runner',
-               lambda: mock_runner):
+    with patch('pipeline.run_beam_tables.get_beam_pipeline_runner',
+               lambda _: mock_runner):
       args = argparse.Namespace(
           full=False,
           scan_type='echo',

--- a/schedule_pipeline.py
+++ b/schedule_pipeline.py
@@ -27,6 +27,7 @@ from mirror.untar_files.sync_files import get_firehook_scanfile_mirror
 from mirror.routeviews.sync_routeviews import get_firehook_routeview_mirror
 from mirror.internal.sync import get_censoredplanet_mirror
 from table.run_queries import rebuild_all_tables
+import firehook_resources
 
 
 def run_pipeline() -> None:
@@ -44,13 +45,14 @@ def run_pipeline() -> None:
     # which in our case requires packaging up many google cloud packages
     # which is slow (hangs basic worker machines) and wasteful.
     subprocess.run([
-        sys.executable, '-m', 'pipeline.run_beam_tables', '--env=prod',
+        sys.executable, '-m', 'pipeline.run_beam_tables', '--env=dev',
         '--scan_type=all'
     ],
                    check=True,
                    stdout=subprocess.PIPE)
 
-    rebuild_all_tables()
+    # TODO update this to prod once we move the queries from the dev project.
+    rebuild_all_tables(firehook_resources.DEV_PROJECT_NAME)
   except Exception:
     # If something goes wrong also log to GCP error console.
     error_reporting.Client().report_exception()


### PR DESCRIPTION
Split out the scripting/command line pieces for running/deploying the pipeline into dev (old `firehook-censoredplanet`) and prod (new `censoredplanet-analysisv1`) projects.

Some parts of this don't yet work entirely, (for example we can't actually run the pipeline in the new project because we need to do some more setup work around permissions and bucket creation.) And some of the buckets in `firehook_resources.py` will need to also be split out into further dev/prod pieces.

Status of the various deployment/command line pieces:
- `manual_e2e_test.py`: runs against dev
- `run_queries.py`: can run queries in both prod and dev, only reads/writes data to the dev project.
- `run_beam_pipeline.py`: works for dev, fails for prod
- `schedule_beam_pipeline.py`: set to only work for dev currently
- `deploy.sh`: set to only work for dev currently
- `data_transfer.py`: works for dev, won't be used in prod