### PR TITLE
prod queries read/write to prod tables

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -75,7 +75,7 @@ existing base tables.
 Runs an appending Apache Beam pipeline. This will check for new unprocessed
 data, and process and append it to the base tables if they exist.
 
- `python -m table.run_queries`
+ `python -m table.run_queries --env=dev`
 
 Runs queries to recreate any tables derived from the base tables.
 

--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -577,6 +577,7 @@ class PipelineManualE2eTest(unittest.TestCase):
       run_queries._run_query(
           client,
           'table/queries/merged_reduced_scans.sql',
+          firehook_resources.DEV_PROJECT_NAME,
           BEAM_TEST_BASE_DATASET,
           BEAM_TEST_BASE_DATASET,
       )
@@ -641,6 +642,7 @@ class PipelineManualE2eTest(unittest.TestCase):
       run_queries._run_query(
           client,
           'table/queries/derived_satellite_scans.sql',
+          firehook_resources.DEV_PROJECT_NAME,
           BEAM_TEST_BASE_DATASET,
           BEAM_TEST_BASE_DATASET,
       )

--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -141,7 +141,7 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
 # Rely on the table name firehook-censoredplanet.derived.merged_reduced_scans_vN
 # if you would like to see a clear breakage when there's a backwards-incompatible change.
 # Old table versions will be deleted.
-CREATE OR REPLACE TABLE `firehook-censoredplanet.DERIVED_DATASET.reduced_satellite_scans_v1`
+CREATE OR REPLACE TABLE `PROJECT_NAME.DERIVED_DATASET.reduced_satellite_scans_v1`
 PARTITION BY date
 # Column `country_name` is always used for filtering and must come first.
 # `network`, `subnetwork`, and `domain` are useful for filtering and grouping.
@@ -168,7 +168,7 @@ WITH Grouped AS (
         OutcomeString(domain, received_error, received_rcode, answers) as outcome,
         
         COUNT(1) AS count
-    FROM `firehook-censoredplanet.BASE_DATASET.satellite_scan`
+    FROM `PROJECT_NAME.BASE_DATASET.satellite_scan`
     # Filter on controls_failed to potentially reduce the number of output rows (less dimensions to group by).
     WHERE domain_controls_failed = FALSE
           AND NOT BadResolver(resolver_connect_error_rate,
@@ -192,7 +192,7 @@ SELECT
         ELSE 0
     END AS expected_count,
     FROM Grouped
-    LEFT JOIN `firehook-censoredplanet.metadata.country_names` USING (country_code)
+    LEFT JOIN `PROJECT_NAME.metadata.country_names` USING (country_code)
     WHERE country_code IS NOT NULL
 );
 

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -29,7 +29,7 @@ CREATE TEMP FUNCTION AddOutcomeEmoji(outcome STRING) AS (
 # Rely on the table name firehook-censoredplanet.derived.merged_reduced_scans_vN
 # if you would like to see a clear breakage when there's a backwards-incompatible change.
 # Old table versions will be deleted.
-CREATE OR REPLACE TABLE `firehook-censoredplanet.DERIVED_DATASET.merged_reduced_scans_v2`
+CREATE OR REPLACE TABLE `PROJECT_NAME.DERIVED_DATASET.merged_reduced_scans_v2`
 PARTITION BY date
 # Columns `source` and `country_name` are always used for filtering and must come first.
 # `network` and `domain` are useful for filtering and grouping.
@@ -41,16 +41,16 @@ OPTIONS (
 AS (
 WITH AllScans AS (
   SELECT * EXCEPT (source), "DISCARD" AS source
-  FROM `firehook-censoredplanet.BASE_DATASET.discard_scan`
+  FROM `PROJECT_NAME.BASE_DATASET.discard_scan`
   UNION ALL
   SELECT * EXCEPT (source), "ECHO" AS source
-  FROM `firehook-censoredplanet.BASE_DATASET.echo_scan`
+  FROM `PROJECT_NAME.BASE_DATASET.echo_scan`
   UNION ALL
   SELECT * EXCEPT (source), "HTTP" AS source
-  FROM `firehook-censoredplanet.BASE_DATASET.http_scan`
+  FROM `PROJECT_NAME.BASE_DATASET.http_scan`
   UNION ALL
   SELECT * EXCEPT (source), "HTTPS" AS source
-  FROM `firehook-censoredplanet.BASE_DATASET.https_scan`
+  FROM `PROJECT_NAME.BASE_DATASET.https_scan`
 ), Grouped AS (
     SELECT
         date,
@@ -78,7 +78,7 @@ SELECT
         WHEN (STARTS_WITH(outcome, "❔")) THEN NULL
     END AS unexpected_count
     FROM Grouped
-    LEFT JOIN `firehook-censoredplanet.metadata.country_names` USING (country_code)
+    LEFT JOIN `PROJECT_NAME.metadata.country_names` USING (country_code)
     WHERE country_code IS NOT NULL
 );
 
@@ -89,8 +89,8 @@ DROP FUNCTION AddOutcomeEmoji;
 # This view is the stable name for the table above.
 # Rely on the table name firehook-censoredplanet.derived.merged_reduced_scans
 # if you would like to continue pointing to the table even when there is a breaking change.
-CREATE OR REPLACE VIEW `firehook-censoredplanet.DERIVED_DATASET.merged_reduced_scans`
+CREATE OR REPLACE VIEW `PROJECT_NAME.DERIVED_DATASET.merged_reduced_scans`
 AS (
   SELECT *
-  FROM `firehook-censoredplanet.DERIVED_DATASET.merged_reduced_scans_v2`
+  FROM `PROJECT_NAME.DERIVED_DATASET.merged_reduced_scans_v2`
 )

--- a/table/run_queries.py
+++ b/table/run_queries.py
@@ -26,6 +26,7 @@ from google.cloud import bigquery as cloud_bigquery  # type: ignore
 
 import firehook_resources
 
+PROJECT_NAME_PLACEHOLDER = 'PROJECT_NAME'
 BASE_PLACEHOLDER = 'BASE_DATASET'
 DERIVED_PLACEHOLDER = 'DERIVED_DATASET'
 
@@ -33,11 +34,13 @@ DEFAULT_BASE_DATASET = 'base'
 DEFAULT_DERIVED_DATASET = 'derived'
 
 
-def _run_query(client: cloud_bigquery.Client, filepath: str, base_dataset: str,
+def _run_query(client: cloud_bigquery.Client, filepath: str, project_name: str,
+               base_dataset: str,
                derived_dataset: str) -> cloud_bigquery.table.RowIterator:
   with open(filepath, encoding='utf-8') as sql:
     query = sql.read()
 
+    query = query.replace(PROJECT_NAME_PLACEHOLDER, project_name)
     query = query.replace(BASE_PLACEHOLDER, base_dataset)
     query = query.replace(DERIVED_PLACEHOLDER, derived_dataset)
 
@@ -59,7 +62,7 @@ def rebuild_all_tables(project_name: str,
 
   for filepath in glob.glob('table/queries/derived_satellite_scans.sql'):
     try:
-      _run_query(client, filepath, base_dataset, derived_dataset)
+      _run_query(client, filepath, project_name, base_dataset, derived_dataset)
     except Exception as ex:
       pprint(('Failed SQL query', filepath))
       raise ex


### PR DESCRIPTION
Follow up to https://github.com/censoredplanet/censoredplanet-analysis/pull/201

Switches the prod queries to not just run in the prod project, but on the prod tables. This doesn't work yet as no prod tables exist. But it does fail with the right errors.

tested: e2e test passed