### PR TITLE
fix satellite e2e test

### DIFF
--- a/pipeline/e2e_test_data/Satellitev2-2021-10-20/resolver_info.json
+++ b/pipeline/e2e_test_data/Satellitev2-2021-10-20/resolver_info.json
@@ -1,0 +1,12 @@
+{"resolver": "208.67.222.123", "non_zero_rcode": "0.1290", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.0000"}
+{"resolver": "114.141.52.91", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "68.94.157.11", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "208.67.222.222", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "208.67.222.123", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "212.185.180.3", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "161.52.1.31", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "62.80.182.26", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "213.142.192.50", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "203.144.128.194", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "116.63.159.66", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}
+{"resolver": "210.27.176.200", "non_zero_rcode": "0.1230", "private_ip": "0.0000", "zero_ip": "0.0000", "connect_error": "0.0000", "invalid_cert": "0.1111"}

--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -639,12 +639,8 @@ class PipelineManualE2eTest(unittest.TestCase):
       # pylint: enable=protected-access
 
       written_derived_rows = get_bq_rows(client, [derived_table_name])
-      self.assertEqual(len(written_derived_rows), 29)
-      expected_domains = (['CONTROL'] + expected_single_domains +
-                          expected_double_domains + expected_triple_domains +
-                          expected_quad_domains)
-      # alipay is filtered out for udp timeouts
-      expected_domains.remove('alipay.com')
+      self.assertEqual(len(written_derived_rows), 1)
+      expected_domains = ['11st.co.kr']
 
       written_derived_domains = [row[5] for row in written_derived_rows]
       self.assertEqual(set(written_derived_domains), set(expected_domains))


### PR DESCRIPTION
I forgot to update the satellite e2e test for the new changes in https://github.com/censoredplanet/censoredplanet-analysis/pull/192 and https://github.com/censoredplanet/censoredplanet-analysis/pull/195 so it was failing. This changes it so it works.

Because PR195 is filtering measurements where the resolver doesn't have resolver_info information (see [here](https://censoredplanet.slack.com/archives/C01DK5FF4KD/p1669292297763369)) we end up filtering all but one line. This is fine, since the point of the test is more to sanity check the process of running the query than the actual query output.