### PR TITLE
split out dev/prod locations for staging and output buckets

### DIFF
--- a/firehook_resources.py
+++ b/firehook_resources.py
@@ -31,9 +31,12 @@ MAXMIND_FILE_LOCATION = f'gs://{METADATA_BUCKET}/maxmind/'
 DBIP_FILE_LOCATION = f'gs://{METADATA_BUCKET}/dbip/'
 
 # Output GCS Buckets
-# TODO: define separate buckets for prod and test
-OUTPUT_BUCKET = 'firehook-test'
+DEV_OUTPUT_BUCKET = 'firehook-test'
+PROD_OUTPUT_BUCKET = 'censoredplanetraw'
 
 # Temp Buckets
-BEAM_STAGING_LOCATION = 'gs://firehook-dataflow-test/staging'
-BEAM_TEMP_LOCATION = 'gs://firehook-dataflow-test/temp'
+DEV_BEAM_STAGING_LOCATION = 'gs://firehook-dataflow-test/staging'
+DEV_BEAM_TEMP_LOCATION = 'gs://firehook-dataflow-test/temp'
+
+PROD_BEAM_STAGING_LOCATION = 'gs://censoredplanet-analysis-beam-staging/staging'
+PROD_BEAM_TEMP_LOCATION = 'gs://censoredplanet-analysis-beam-staging/temp'

--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -341,22 +341,24 @@ def _custom_file_naming(suffix: Optional[str] = None) -> Callable:
 class ScanDataBeamPipelineRunner():
   """A runner to collect cloud values and run a corrosponding beam pipeline."""
 
-  def __init__(self, project: str, bucket: str, staging_location: str,
-               temp_location: str,
+  def __init__(self, project: str, input_bucket: str, staging_location: str,
+               temp_location: str, output_bucket: str,
                metadata_chooser_factory: IpMetadataChooserFactory) -> None:
     """Initialize a pipeline runner.
 
     Args:
       project: google cluod project name
-      bucket: gcs bucket name
+      input_bucket: gcs bucket name
       staging_location: gcs bucket name, used for staging beam data
       temp_location: gcs bucket name, used for temp beam data
+      output_bucket: gcs bucket name, used when writing to GCS (instead of bq)
       metadata_chooser: factory to create a metadata chooser
     """
     self.project = project
-    self.bucket = bucket
+    self.input_bucket = input_bucket
     self.staging_location = staging_location
     self.temp_location = temp_location
+    self.output_bucket = output_bucket
     self.metadata_adder = MetadataAdder(metadata_chooser_factory)
 
   def _get_full_table_name(self, table_name: str) -> str:
@@ -413,7 +415,7 @@ class ScanDataBeamPipelineRunner():
       files_to_load = SCAN_FILES
 
     # Filepath like `gs://firehook-scans/echo/**/*'
-    files_regex = f'{self.bucket}{scan_type}/**/*'
+    files_regex = f'{self.input_bucket}{scan_type}/**/*'
     file_metadata = [m.metadata_list for m in gcs.match([files_regex])][0]
 
     filepaths = [metadata.path for metadata in file_metadata]

--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -201,7 +201,7 @@ def get_local_pipeline_options(*_: List[Any]) -> PipelineOptions:
       runner='DirectRunner',
       job_name=JOB_NAME,
       project=firehook_resources.DEV_PROJECT_NAME,
-      temp_location=firehook_resources.BEAM_TEMP_LOCATION)
+      temp_location=firehook_resources.DEV_BEAM_TEMP_LOCATION)
 
 
 def run_local_pipeline(scan_type: str, incremental: bool) -> None:

--- a/pipeline/run_beam_tables.py
+++ b/pipeline/run_beam_tables.py
@@ -25,7 +25,6 @@ from typing import Optional, List
 
 from pipeline import beam_tables
 from pipeline.metadata.ip_metadata_chooser import IpMetadataChooserFactory
-from firehook_resources import OUTPUT_BUCKET
 
 
 def run_parallel_pipelines(runner: beam_tables.ScanDataBeamPipelineRunner,
@@ -63,7 +62,7 @@ def run_parallel_pipelines(runner: beam_tables.ScanDataBeamPipelineRunner,
       gcs_folder = None
       if export_gcs:
         gcs_folder = beam_tables.get_gcs_folder(dataset, scan_type,
-                                                OUTPUT_BUCKET)
+                                                runner.output_bucket)
         job_name = beam_tables.get_gcs_job_name(gcs_folder, incremental_load)
       else:
         table_name = beam_tables.get_table_name(dataset, scan_type,
@@ -109,13 +108,20 @@ def get_beam_pipeline_runner(
 
   if env in ('dev', 'user'):
     project_name = firehook_resources.DEV_PROJECT_NAME
+    staging_location = firehook_resources.DEV_BEAM_STAGING_LOCATION
+    temp_location = firehook_resources.DEV_BEAM_TEMP_LOCATION
+    output_bucket = firehook_resources.DEV_OUTPUT_BUCKET
   if env == 'prod':
     project_name = firehook_resources.PROD_PROJECT_NAME
+    staging_location = firehook_resources.PROD_BEAM_STAGING_LOCATION
+    temp_location = firehook_resources.PROD_BEAM_TEMP_LOCATION
+    output_bucket = firehook_resources.PROD_OUTPUT_BUCKET
 
-  return beam_tables.ScanDataBeamPipelineRunner(
-      project_name, firehook_resources.INPUT_BUCKET,
-      firehook_resources.BEAM_STAGING_LOCATION,
-      firehook_resources.BEAM_TEMP_LOCATION, metadata_chooser_factory)
+  return beam_tables.ScanDataBeamPipelineRunner(project_name,
+                                                firehook_resources.INPUT_BUCKET,
+                                                staging_location, temp_location,
+                                                output_bucket,
+                                                metadata_chooser_factory)
 
 
 def main(parsed_args: argparse.Namespace) -> None:

--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -83,7 +83,7 @@ class PipelineMainTest(unittest.TestCase):
   def test_get_full_table_name(self) -> None:
     project = 'firehook-censoredplanet'
     runner = beam_tables.ScanDataBeamPipelineRunner(
-        project, '', '', '', FakeIpMetadataChooserFactory())
+        project, '', '', '', '', FakeIpMetadataChooserFactory())
 
     full_name = runner._get_full_table_name('prod.echo_scan')
     self.assertEqual(full_name, 'firehook-censoredplanet:prod.echo_scan')

--- a/pipeline/test_run_beam_tables.py
+++ b/pipeline/test_run_beam_tables.py
@@ -32,6 +32,7 @@ class RunBeamTablesTest(unittest.TestCase):
   def test_run_single_pipelines(self) -> None:
     """Test running a single dated pipeline."""
     mock_runner = MagicMock(beam_tables.ScanDataBeamPipelineRunner)
+    mock_runner.output_bucket = 'firehook-test'
 
     run_beam_tables.run_parallel_pipelines(mock_runner, 'base', ['echo'], True,
                                            datetime.date(2020, 1, 1),
@@ -56,6 +57,7 @@ class RunBeamTablesTest(unittest.TestCase):
   def test_run_parallel_pipelines(self) -> None:
     """Test running two pipelines in parallel."""
     mock_runner = MagicMock(beam_tables.ScanDataBeamPipelineRunner)
+    mock_runner.output_bucket = 'firehook-test'
 
     run_beam_tables.run_parallel_pipelines(mock_runner, 'laplante',
                                            ['http', 'https'], False, None, None,
@@ -82,6 +84,7 @@ class RunBeamTablesTest(unittest.TestCase):
   def test_main_prod(self) -> None:
     """Test arg parsing for prod pipelines."""
     mock_runner = MagicMock(beam_tables.ScanDataBeamPipelineRunner)
+    mock_runner.output_bucket = 'firehook-test'
 
     with patch('pipeline.run_beam_tables.get_beam_pipeline_runner',
                lambda _: mock_runner):
@@ -136,6 +139,7 @@ class RunBeamTablesTest(unittest.TestCase):
   def test_main_user_dates(self) -> None:
     """Test arg parsing for a user pipeline with dates."""
     mock_runner = MagicMock(beam_tables.ScanDataBeamPipelineRunner)
+    mock_runner.output_bucket = 'firehook-test'
 
     with patch('pipeline.run_beam_tables.get_beam_pipeline_runner',
                lambda _: mock_runner):


### PR DESCRIPTION
This separates out the DEV/PROD buckets used:
- for temp writing during the pipeline
- for writing output files from the pipeline

This does not separate the input/metadata buckets. Those are still all in the dev project.

tested: e2e test, running some `python3 -m pipeline.run_beam_tables ...` examples