### PR TITLE
preliminary emoji changes

### DIFF
--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -1,30 +1,30 @@
 # https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 CREATE TEMP FUNCTION ClassifySatelliteRCode(rcode INTEGER) AS (
   CASE
-    WHEN rcode = 1 THEN "❓dns/rcode:FormErr"
+    WHEN rcode = 1 THEN "❗️dns/rcode:FormErr"
     WHEN rcode = 2 THEN "❓dns/rcode:ServFail"
     WHEN rcode = 3 THEN "❗️dns/rcode:NXDomain"
-    WHEN rcode = 4 THEN "❓dns/rcode:NotImp"
+    WHEN rcode = 4 THEN "❗️dns/rcode:NotImp"
     WHEN rcode = 5 THEN "❗️dns/rcode:Refused"
-    WHEN rcode = 6 THEN "❓dns/rcode:YXDomain"
-    WHEN rcode = 7 THEN "❓dns/rcode:YXRRSet"
-    WHEN rcode = 8 THEN "❓dns/rcode:NXRRSet"
-    WHEN rcode = 9 THEN "❓dns/rcode:NotAuth"
-    WHEN rcode = 10 THEN "❓dns/rcode:NotZone"
-    WHEN rcode = 11 THEN "❓dns/rcode:DSOTYPENI"
-    WHEN rcode = 12 THEN "❓dns/rcode:Unassigned"
-    WHEN rcode = 13 THEN "❓dns/rcode:Unassigned"
-    WHEN rcode = 14 THEN "❓dns/rcode:Unassigned"
-    WHEN rcode = 15 THEN "❓dns/rcode:Unassigned"
-    WHEN rcode = 16 THEN "❓dns/rcode:BadVers"
-    WHEN rcode = 17 THEN "❓dns/rcode:BadSig"
-    WHEN rcode = 18 THEN "❓dns/rcode:BadKey"
-    WHEN rcode = 19 THEN "❓dns/rcode:BadTime"
-    WHEN rcode = 20 THEN "❓dns/rcode:BadMode"
-    WHEN rcode = 21 THEN "❓dns/rcode:BadAlg"
-    WHEN rcode = 22 THEN "❓dns/rcode:BadTrunc"
-    WHEN rcode = 23 THEN "❓dns/rcode:BadCookie"
-    ELSE CONCAT("❓dns/unknown_rcode:", rcode)
+    WHEN rcode = 6 THEN "❗️dns/rcode:YXDomain"
+    WHEN rcode = 7 THEN "❗️dns/rcode:YXRRSet"
+    WHEN rcode = 8 THEN "❗️dns/rcode:NXRRSet"
+    WHEN rcode = 9 THEN "❗️dns/rcode:NotAuth"
+    WHEN rcode = 10 THEN "❗️dns/rcode:NotZone"
+    WHEN rcode = 11 THEN "❗️dns/rcode:DSOTYPENI"
+    WHEN rcode = 12 THEN "❗️dns/rcode:Unassigned"
+    WHEN rcode = 13 THEN "❗️dns/rcode:Unassigned"
+    WHEN rcode = 14 THEN "❗️dns/rcode:Unassigned"
+    WHEN rcode = 15 THEN "❗️dns/rcode:Unassigned"
+    WHEN rcode = 16 THEN "❗️dns/rcode:BadVers"
+    WHEN rcode = 17 THEN "❗️dns/rcode:BadSig"
+    WHEN rcode = 18 THEN "❗️dns/rcode:BadKey"
+    WHEN rcode = 19 THEN "❗️dns/rcode:BadTime"
+    WHEN rcode = 20 THEN "❗️dns/rcode:BadMode"
+    WHEN rcode = 21 THEN "❗️dns/rcode:BadAlg"
+    WHEN rcode = 22 THEN "❗️dns/rcode:BadTrunc"
+    WHEN rcode = 23 THEN "❗️dns/rcode:BadCookie"
+    ELSE CONCAT("❗️dns/unknown_rcode:", rcode)
   END
 );
 
@@ -32,21 +32,21 @@ CREATE TEMP FUNCTION ClassifySatelliteError(error STRING) AS (
   CASE
     # Satellite v1
     WHEN REGEXP_CONTAINS(error, '"Err": {}') THEN "❓read/udp.timeout"
-    WHEN REGEXP_CONTAINS(error, '"Err": 90') THEN "❓read/dns.msgsize"
-    WHEN REGEXP_CONTAINS(error, '"Err": 111') THEN "❓read/udp.refused"
-    WHEN REGEXP_CONTAINS(error, '"Err": 113') THEN "❓read/ip.host_no_route"
+    WHEN REGEXP_CONTAINS(error, '"Err": 90') THEN "❗️read/dns.msgsize"
+    WHEN REGEXP_CONTAINS(error, '"Err": 111') THEN "❗️read/udp.refused"
+    WHEN REGEXP_CONTAINS(error, '"Err": 113') THEN "❗️read/ip.host_no_route"
     WHEN REGEXP_CONTAINS(error, '"Err": 24') THEN "❔setup/system_failure" # Too many open files
-    WHEN error = "{}" THEN "❓dns/unknown" # TODO figure out origin
-    WHEN error = "no_answer" THEN "❓dns/answer:no_answer"
+    WHEN error = "{}" THEN "❗️dns/unknown" # TODO figure out origin
+    WHEN error = "no_answer" THEN "❗️dns/answer:no_answer"
     #Satellite v2
     WHEN ENDS_WITH(error, "i/o timeout") THEN "❓read/udp.timeout"
-    WHEN ENDS_WITH(error, "message too long") THEN "❓read/dns.msgsize"
-    WHEN ENDS_WITH(error, "connection refused") THEN "❓read/udp.refused"
-    WHEN ENDS_WITH(error, "no route to host") THEN "❓read/ip.host_no_route"
-    WHEN ENDS_WITH(error, "short read") THEN "❓read/dns.msgsize"
-    WHEN ENDS_WITH(error, "read: protocol error") THEN "❓read/protocol_error"
+    WHEN ENDS_WITH(error, "message too long") THEN "❗️read/dns.msgsize"
+    WHEN ENDS_WITH(error, "connection refused") THEN "❗️read/udp.refused"
+    WHEN ENDS_WITH(error, "no route to host") THEN "❗️read/ip.host_no_route"
+    WHEN ENDS_WITH(error, "short read") THEN "❗️read/dns.msgsize"
+    WHEN ENDS_WITH(error, "read: protocol error") THEN "❗️read/protocol_error"
     WHEN ENDS_WITH(error, "socket: too many open files") THEN "❔setup/system_failure"
-    ELSE CONCAT("❓dns/unknown_error:", error)
+    ELSE CONCAT("❗️dns/unknown_error:", error)
   END
 );
 
@@ -103,7 +103,7 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
         # TODO fix -1 rcodes in v1 data in the pipeline
         WHEN rcode = -1 THEN "❓read/udp.timeout"
         WHEN rcode != 0 THEN ClassifySatelliteRCode(rcode)
-        WHEN ARRAY_LENGTH(answers) = 0 THEN "❓answer:no_answer"
+        WHEN ARRAY_LENGTH(answers) = 0 THEN "❗️answer:no_answer"
         ELSE IFNULL(
             (SELECT InvalidIpType(answer.ip) FROM UNNEST(answers) answer LIMIT 1),
             CASE

--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -1,52 +1,52 @@
 # https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
 CREATE TEMP FUNCTION ClassifySatelliteRCode(rcode INTEGER) AS (
   CASE
-    WHEN rcode = 1 THEN "⚠️dns/rcode:FormErr"
-    WHEN rcode = 2 THEN "⚠️dns/rcode:ServFail"
+    WHEN rcode = 1 THEN "❓dns/rcode:FormErr"
+    WHEN rcode = 2 THEN "❓dns/rcode:ServFail"
     WHEN rcode = 3 THEN "❗️dns/rcode:NXDomain"
-    WHEN rcode = 4 THEN "⚠️dns/rcode:NotImp"
+    WHEN rcode = 4 THEN "❓dns/rcode:NotImp"
     WHEN rcode = 5 THEN "❗️dns/rcode:Refused"
-    WHEN rcode = 6 THEN "⚠️dns/rcode:YXDomain"
-    WHEN rcode = 7 THEN "⚠️dns/rcode:YXRRSet"
-    WHEN rcode = 8 THEN "⚠️dns/rcode:NXRRSet"
-    WHEN rcode = 9 THEN "⚠️dns/rcode:NotAuth"
-    WHEN rcode = 10 THEN "⚠️dns/rcode:NotZone"
-    WHEN rcode = 11 THEN "⚠️dns/rcode:DSOTYPENI"
-    WHEN rcode = 12 THEN "⚠️dns/rcode:Unassigned"
-    WHEN rcode = 13 THEN "⚠️dns/rcode:Unassigned"
-    WHEN rcode = 14 THEN "⚠️dns/rcode:Unassigned"
-    WHEN rcode = 15 THEN "⚠️dns/rcode:Unassigned"
-    WHEN rcode = 16 THEN "⚠️dns/rcode:BadVers"
-    WHEN rcode = 17 THEN "⚠️dns/rcode:BadSig"
-    WHEN rcode = 18 THEN "⚠️dns/rcode:BadKey"
-    WHEN rcode = 19 THEN "⚠️dns/rcode:BadTime"
-    WHEN rcode = 20 THEN "⚠️dns/rcode:BadMode"
-    WHEN rcode = 21 THEN "⚠️dns/rcode:BadAlg"
-    WHEN rcode = 22 THEN "⚠️dns/rcode:BadTrunc"
-    WHEN rcode = 23 THEN "⚠️dns/rcode:BadCookie"
-    ELSE CONCAT("⚠️dns/unknown_rcode:", rcode)
+    WHEN rcode = 6 THEN "❓dns/rcode:YXDomain"
+    WHEN rcode = 7 THEN "❓dns/rcode:YXRRSet"
+    WHEN rcode = 8 THEN "❓dns/rcode:NXRRSet"
+    WHEN rcode = 9 THEN "❓dns/rcode:NotAuth"
+    WHEN rcode = 10 THEN "❓dns/rcode:NotZone"
+    WHEN rcode = 11 THEN "❓dns/rcode:DSOTYPENI"
+    WHEN rcode = 12 THEN "❓dns/rcode:Unassigned"
+    WHEN rcode = 13 THEN "❓dns/rcode:Unassigned"
+    WHEN rcode = 14 THEN "❓dns/rcode:Unassigned"
+    WHEN rcode = 15 THEN "❓dns/rcode:Unassigned"
+    WHEN rcode = 16 THEN "❓dns/rcode:BadVers"
+    WHEN rcode = 17 THEN "❓dns/rcode:BadSig"
+    WHEN rcode = 18 THEN "❓dns/rcode:BadKey"
+    WHEN rcode = 19 THEN "❓dns/rcode:BadTime"
+    WHEN rcode = 20 THEN "❓dns/rcode:BadMode"
+    WHEN rcode = 21 THEN "❓dns/rcode:BadAlg"
+    WHEN rcode = 22 THEN "❓dns/rcode:BadTrunc"
+    WHEN rcode = 23 THEN "❓dns/rcode:BadCookie"
+    ELSE CONCAT("❓dns/unknown_rcode:", rcode)
   END
 );
 
 CREATE TEMP FUNCTION ClassifySatelliteError(error STRING) AS (
   CASE
     # Satellite v1
-    WHEN REGEXP_CONTAINS(error, '"Err": {}') THEN "⚠️read/udp.timeout"
-    WHEN REGEXP_CONTAINS(error, '"Err": 90') THEN "⚠️read/dns.msgsize"
-    WHEN REGEXP_CONTAINS(error, '"Err": 111') THEN "⚠️read/udp.refused"
-    WHEN REGEXP_CONTAINS(error, '"Err": 113') THEN "⚠️read/ip.host_no_route"
-    WHEN REGEXP_CONTAINS(error, '"Err": 24') THEN "setup/system_failure" # Too many open files
-    WHEN error = "{}" THEN "⚠️dns/unknown" # TODO figure out origin
-    WHEN error = "no_answer" THEN "⚠️dns/answer:no_answer"
+    WHEN REGEXP_CONTAINS(error, '"Err": {}') THEN "❓read/udp.timeout"
+    WHEN REGEXP_CONTAINS(error, '"Err": 90') THEN "❓read/dns.msgsize"
+    WHEN REGEXP_CONTAINS(error, '"Err": 111') THEN "❓read/udp.refused"
+    WHEN REGEXP_CONTAINS(error, '"Err": 113') THEN "❓read/ip.host_no_route"
+    WHEN REGEXP_CONTAINS(error, '"Err": 24') THEN "❔setup/system_failure" # Too many open files
+    WHEN error = "{}" THEN "❓dns/unknown" # TODO figure out origin
+    WHEN error = "no_answer" THEN "❓dns/answer:no_answer"
     #Satellite v2
-    WHEN ENDS_WITH(error, "i/o timeout") THEN "⚠️read/udp.timeout"
-    WHEN ENDS_WITH(error, "message too long") THEN "⚠️read/dns.msgsize"
-    WHEN ENDS_WITH(error, "connection refused") THEN "⚠️read/udp.refused"
-    WHEN ENDS_WITH(error, "no route to host") THEN "⚠️read/ip.host_no_route"
-    WHEN ENDS_WITH(error, "short read") THEN "⚠️read/dns.msgsize"
-    WHEN ENDS_WITH(error, "read: protocol error") THEN "⚠️read/protocol_error"
-    WHEN ENDS_WITH(error, "socket: too many open files") THEN "setup/system_failure"
-    ELSE CONCAT("⚠️dns/unknown_error:", error)
+    WHEN ENDS_WITH(error, "i/o timeout") THEN "❓read/udp.timeout"
+    WHEN ENDS_WITH(error, "message too long") THEN "❓read/dns.msgsize"
+    WHEN ENDS_WITH(error, "connection refused") THEN "❓read/udp.refused"
+    WHEN ENDS_WITH(error, "no route to host") THEN "❓read/ip.host_no_route"
+    WHEN ENDS_WITH(error, "short read") THEN "❓read/dns.msgsize"
+    WHEN ENDS_WITH(error, "read: protocol error") THEN "❓read/protocol_error"
+    WHEN ENDS_WITH(error, "socket: too many open files") THEN "❔setup/system_failure"
+    ELSE CONCAT("❓dns/unknown_error:", error)
   END
 );
 
@@ -101,9 +101,9 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
               AND dns_error != "null"
               AND dns_error != "SERVFAIL") THEN ClassifySatelliteError(dns_error)
         # TODO fix -1 rcodes in v1 data in the pipeline
-        WHEN rcode = -1 THEN "⚠️read/udp.timeout"
+        WHEN rcode = -1 THEN "❓read/udp.timeout"
         WHEN rcode != 0 THEN ClassifySatelliteRCode(rcode)
-        WHEN ARRAY_LENGTH(answers) = 0 THEN "⚠️answer:no_answer"
+        WHEN ARRAY_LENGTH(answers) = 0 THEN "❓answer:no_answer"
         ELSE IFNULL(
             (SELECT InvalidIpType(answer.ip) FROM UNNEST(answers) answer LIMIT 1),
             CASE
@@ -129,7 +129,7 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
                 WHEN (SELECT LOGICAL_OR(answer.matches_control.asn)
                       FROM UNNEST(answers) answer)
                       THEN "✅answer:matches_asn"
-                ELSE CONCAT("⚠️answer:not_validated:", AnswersSignature(answers))
+                ELSE CONCAT("❓answer:not_validated:", AnswersSignature(answers))
             END
         )
     END
@@ -199,19 +199,19 @@ WITH Grouped AS (
                               resolver_non_zero_rcode_rate)
     GROUP BY a.date, hostname, country_code, network, subnetwork, outcome, domain, category
     # Filter it here so that we don't need to load the outcome to apply the report filtering on every filter.
-    HAVING NOT STARTS_WITH(outcome, "setup/")
+    HAVING NOT STARTS_WITH(outcome, "❔setup/")
 )
 SELECT
     Grouped.* EXCEPT (country_code),
     IFNULL(country_name, country_code) AS country_name,
     CASE
         WHEN STARTS_WITH(outcome, "✅") THEN 0
-        WHEN outcome = "⚠️read/udp.timeout" THEN NULL # timeouts are common in dns
+        WHEN outcome = "❓read/udp.timeout" THEN NULL # timeouts are common in dns
         ELSE count
     END AS unexpected_count,
     CASE
         WHEN STARTS_WITH(outcome, "✅") THEN count
-        WHEN outcome = "⚠️read/udp.timeout" THEN NULL
+        WHEN outcome = "❓read/udp.timeout" THEN NULL
         ELSE 0
     END AS expected_count,
     FROM Grouped

--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -34,7 +34,7 @@ CREATE TEMP FUNCTION ClassifySatelliteError(error STRING) AS (
     WHEN REGEXP_CONTAINS(error, '"Err": {}') THEN "❓read/udp.timeout"
     WHEN REGEXP_CONTAINS(error, '"Err": 90') THEN "❗️read/dns.msgsize"
     WHEN REGEXP_CONTAINS(error, '"Err": 111') THEN "❗️read/udp.refused"
-    WHEN REGEXP_CONTAINS(error, '"Err": 113') THEN "❗️read/ip.host_no_route"
+    WHEN REGEXP_CONTAINS(error, '"Err": 113') THEN "❔read/ip.host_no_route"
     WHEN REGEXP_CONTAINS(error, '"Err": 24') THEN "❔setup/system_failure" # Too many open files
     WHEN error = "{}" THEN "❗️dns/unknown" # TODO figure out origin
     WHEN error = "no_answer" THEN "❗️dns/answer:no_answer"
@@ -42,7 +42,7 @@ CREATE TEMP FUNCTION ClassifySatelliteError(error STRING) AS (
     WHEN ENDS_WITH(error, "i/o timeout") THEN "❓read/udp.timeout"
     WHEN ENDS_WITH(error, "message too long") THEN "❗️read/dns.msgsize"
     WHEN ENDS_WITH(error, "connection refused") THEN "❗️read/udp.refused"
-    WHEN ENDS_WITH(error, "no route to host") THEN "❗️read/ip.host_no_route"
+    WHEN ENDS_WITH(error, "no route to host") THEN "❔read/ip.host_no_route"
     WHEN ENDS_WITH(error, "short read") THEN "❗️read/dns.msgsize"
     WHEN ENDS_WITH(error, "read: protocol error") THEN "❗️read/protocol_error"
     WHEN ENDS_WITH(error, "socket: too many open files") THEN "❔setup/system_failure"

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -16,7 +16,10 @@ CREATE TEMP FUNCTION AddOutcomeEmoji(outcome STRING) AS (
   CASE
     WHEN STARTS_WITH(outcome, "setup/") THEN CONCAT("❔", outcome)
     WHEN STARTS_WITH(outcome, "unknown/") THEN CONCAT("❔", outcome)
+    WHEN STARTS_WITH(outcome, "dial/") THEN CONCAT("❔", outcome)
     WHEN STARTS_WITH(outcome, "expected/") THEN CONCAT("✅", SUBSTR(outcome, 10))
+    WHEN STARTS_WITH(outcome, "content/blockpage") THEN CONCAT("❗️", outcome)
+    WHEN STARTS_WITH(outcome, "content") THEN CONCAT("❓", outcome)
     ELSE CONCAT("❗️", outcome)
   END
 );
@@ -75,6 +78,7 @@ SELECT
     CASE
         WHEN (STARTS_WITH(outcome, "✅")) THEN 0
         WHEN (STARTS_WITH(outcome, "❗️")) THEN count
+        WHEN (STARTS_WITH(outcome, "❓")) THEN count
         WHEN (STARTS_WITH(outcome, "❔")) THEN NULL
     END AS unexpected_count
     FROM Grouped

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -20,8 +20,9 @@ CREATE TEMP FUNCTION AddOutcomeEmoji(outcome STRING) AS (
     WHEN STARTS_WITH(outcome, "read/system") THEN CONCAT("❔", outcome)
     WHEN STARTS_WITH(outcome, "expected/") THEN CONCAT("✅", SUBSTR(outcome, 10))
     WHEN STARTS_WITH(outcome, "content/blockpage") THEN CONCAT("❗️", outcome)
-    WHEN STARTS_WITH(outcome, "content") THEN CONCAT("❓", outcome)
-    ELSE CONCAT("❗️", outcome)
+    WHEN STARTS_WITH(outcome, "read/") THEN CONCAT("❗️", outcome)
+    WHEN STARTS_WITH(outcome, "write/") THEN CONCAT("❗️", outcome)
+    ELSE CONCAT("❓", outcome)
   END
 );
 

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -17,6 +17,7 @@ CREATE TEMP FUNCTION AddOutcomeEmoji(outcome STRING) AS (
     WHEN STARTS_WITH(outcome, "setup/") THEN CONCAT("❔", outcome)
     WHEN STARTS_WITH(outcome, "unknown/") THEN CONCAT("❔", outcome)
     WHEN STARTS_WITH(outcome, "dial/") THEN CONCAT("❔", outcome)
+    WHEN STARTS_WITH(outcome, "read/system") THEN CONCAT("❔", outcome)
     WHEN STARTS_WITH(outcome, "expected/") THEN CONCAT("✅", SUBSTR(outcome, 10))
     WHEN STARTS_WITH(outcome, "content/blockpage") THEN CONCAT("❗️", outcome)
     WHEN STARTS_WITH(outcome, "content") THEN CONCAT("❓", outcome)
@@ -70,7 +71,8 @@ WITH AllScans AS (
     WHERE NOT controls_failed
     GROUP BY date, source, country_code, network, outcome, domain, category, subnetwork
     # Filter it here so that we don't need to load the outcome to apply the report filtering on every filter.
-    HAVING NOT STARTS_WITH(outcome, "❔setup/")
+    HAVING (NOT STARTS_WITH(outcome, "❔setup/")
+            AND NOT outcome = "❔read/system")
 )
 SELECT
     Grouped.* EXCEPT (country_code),


### PR DESCRIPTION
Tentative proposal for which emoji to use in the outcome strings.

The new set of emojis (in order of severity) is:
- :white_check_mark: expected
- :grey_question: invalid test
- :question: unexpected
- :exclamation: unexpected and suspicious


Changes:
- :warning: -> :question: as being less confusing
- - This means the two unexpected outcomes are :question: and :exclamation: which are pleasingly visually similar
- dial outcomes in hyperquack are now :grey_question: Am I missing other outcomes that should change to this?
- @ramakrishnansr I think you wanted to downgrade more hyperquack outcomes to :question:. [Which ones](https://github.com/censoredplanet/censoredplanet-analysis/blob/master/pipeline/metadata/test_hyperquack_outcome.py)?

Overall Satellite outcomes ([source](https://datastudio.google.com/c/reporting/c9afebdd-91c8-4381-9b7d-5a9fd083bb90/page/p_mekso35lrc)):
![image](https://user-images.githubusercontent.com/1127209/206792585-9df22337-c085-4cb1-81a5-20be86377a74.png)

Overall Hyperquack outcomes ([source](https://datastudio.google.com/c/reporting/f85a1d2f-23f3-4ccf-876e-8d1338580559/page/p_intendmtxc)):
![image](https://user-images.githubusercontent.com/1127209/212127173-ac27e508-c84c-420d-a9c7-0f02b4577c66.png)

