### PR TITLE
split out metadata locations and allow dev and prod deploys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ FROM python:3.8-buster
 # Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True
 
+# Define env variable to be passed in by deploy.sh
+ENV PIPELINE_ENV change_me
+
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME
@@ -25,4 +28,4 @@ COPY . ./
 
 RUN pip install -r requirements.txt
 
-ENTRYPOINT python3 schedule_pipeline.py
+ENTRYPOINT python3 schedule_pipeline.py --env=${PIPELINE_ENV}

--- a/dev.env
+++ b/dev.env
@@ -1,0 +1,1 @@
+PIPELINE_ENV=dev

--- a/firehook_resources.py
+++ b/firehook_resources.py
@@ -16,17 +16,22 @@
 PROD_PROJECT_NAME = 'censoredplanet-analysisv1'
 DEV_PROJECT_NAME = 'firehook-censoredplanet'
 
-# Buckets that store scanfiles
+# Bucket that stores scanfiles
 SCAN_BUCKET = 'censoredplanetscanspublic'
 INPUT_BUCKET = f'gs://{SCAN_BUCKET}/'
 
-# Buckets that store METADATA information
-# TODO change this bucket name to something metadata related.
-METADATA_BUCKET = 'censoredplanet_geolocation'
 ROUTEVIEW_PATH = 'caida/routeviews/'
-CAIDA_FILE_LOCATION = f'gs://{METADATA_BUCKET}/caida/'
-MAXMIND_FILE_LOCATION = f'gs://{METADATA_BUCKET}/maxmind/'
-DBIP_FILE_LOCATION = f'gs://{METADATA_BUCKET}/dbip/'
+
+# Buckets that store METADATA information
+DEV_METADATA_BUCKET = 'censoredplanet_geolocation'
+DEV_CAIDA_FILE_LOCATION = f'gs://{DEV_METADATA_BUCKET}/caida/'
+DEV_MAXMIND_FILE_LOCATION = f'gs://{DEV_METADATA_BUCKET}/maxmind/'
+DEV_DBIP_FILE_LOCATION = f'gs://{DEV_METADATA_BUCKET}/dbip/'
+
+PROD_METADATA_BUCKET = 'censoredplanet_ip_metadata'
+PROD_CAIDA_FILE_LOCATION = f'gs://{PROD_METADATA_BUCKET}/caida/'
+PROD_MAXMIND_FILE_LOCATION = f'gs://{PROD_METADATA_BUCKET}/maxmind/'
+PROD_DBIP_FILE_LOCATION = f'gs://{PROD_METADATA_BUCKET}/dbip/'
 
 # Output GCS Buckets
 DEV_OUTPUT_BUCKET = 'firehook-test'

--- a/mirror/routeviews/bulk_download.py
+++ b/mirror/routeviews/bulk_download.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Bulk importer for CAIDA routeview files."""
 
+import argparse
 import datetime
 import urllib.request
 
@@ -78,12 +79,30 @@ def download_days_routeview(bucket: storage.bucket.Bucket,
         raise ex
 
 
-def download_manual_routeviews_firehook() -> None:
+def download_manual_routeviews_firehook(env: str) -> None:
+  """Download routeviews for a given project
+
+  Args:
+    env: one of 'dev' or 'prod', which gcloud project env to use.
+  """
   client = storage.Client()
-  bucket = client.get_bucket(firehook_resources.METADATA_BUCKET)
+  if env == 'dev':
+    bucket = client.get_bucket(firehook_resources.DEV_METADATA_BUCKET)
+  if env == 'prod':
+    bucket = client.get_bucket(firehook_resources.PROD_METADATA_BUCKET)
 
   download_manual_routeviews(bucket)
 
 
 if __name__ == "__main__":
-  download_manual_routeviews_firehook()
+  parser = argparse.ArgumentParser(
+      description='Manually download routeview files for project.')
+  parser.add_argument(
+      '--env',
+      type=str,
+      default='dev',
+      choices=['dev', 'prod'],
+      help='Whether to write to prod or dev gcloud project')
+  args = parser.parse_args()
+
+  download_manual_routeviews_firehook(args.env)

--- a/pipeline/manual_e2e_test.py
+++ b/pipeline/manual_e2e_test.py
@@ -669,7 +669,7 @@ class PipelineManualE2eTest(unittest.TestCase):
   def test_ipmetadata_init(self) -> None:
     """Test getting getting routeview metadata from prod."""
     caida_ip_metadata_db = caida_ip_metadata.get_firehook_caida_ip_metadata_db(
-        datetime.date(2018, 7, 27))
+        'dev', datetime.date(2018, 7, 27))
 
     metadata = caida_ip_metadata_db.lookup('1.1.1.1')
     self.assertEqual(metadata, ('1.1.1.0/24', 13335, 'CLOUDFLARENET',
@@ -690,7 +690,7 @@ class PipelineManualE2eTest(unittest.TestCase):
   def test_maxmind_init(self) -> None:
     """Test getting maxmind metadata from prod."""
     maxmind_db = maxmind.MaxmindIpMetadata(
-        firehook_resources.MAXMIND_FILE_LOCATION)
+        firehook_resources.DEV_MAXMIND_FILE_LOCATION)
 
     metadata = maxmind_db.lookup('1.1.1.1')
     self.assertEqual(metadata, ('1.1.1.0/24', 13335, 'CLOUDFLARENET', 'AU'))
@@ -705,7 +705,7 @@ class PipelineManualE2eTest(unittest.TestCase):
 
   def test_dbip_init(self) -> None:
     """Test DBIP database access from prod."""
-    dbip_data = dbip.DbipMetadata(firehook_resources.DBIP_FILE_LOCATION)
+    dbip_data = dbip.DbipMetadata(firehook_resources.DEV_DBIP_FILE_LOCATION)
 
     (org, asn) = dbip_data.lookup('1.211.95.160')
     self.assertEqual(org, "Boranet")

--- a/pipeline/metadata/caida_ip_metadata.py
+++ b/pipeline/metadata/caida_ip_metadata.py
@@ -333,12 +333,14 @@ class FakeCaidaIpMetadata(CaidaIpMetadata):
 
 
 def get_firehook_caida_ip_metadata_db(
+    env: str,
     date: datetime.date,
     allow_previous_day: bool = False,
 ) -> CaidaIpMetadata:
   """Factory to return an CaidaIpMetadata object which reads in firehook files.
 
   Args:
+    env: one of 'dev' or 'prod' which gcloud project env to use.
     date: a date to initialize the asn database to
     allow_previous_day: If the given date's routeview file doesn't exist, allow
       the one from the previous day instead. This is useful when processing very
@@ -349,5 +351,9 @@ def get_firehook_caida_ip_metadata_db(
   """
   # import here to avoid beam pickling issues
   import firehook_resources  # pylint: disable=import-outside-toplevel
-  return CaidaIpMetadata(date, firehook_resources.CAIDA_FILE_LOCATION,
-                         allow_previous_day)
+  if env == 'dev':
+    file_location = firehook_resources.DEV_CAIDA_FILE_LOCATION
+  if env == 'prod':
+    file_location = firehook_resources.DEV_CAIDA_FILE_LOCATION
+
+  return CaidaIpMetadata(date, file_location, allow_previous_day)

--- a/pipeline/run_beam_tables.py
+++ b/pipeline/run_beam_tables.py
@@ -101,17 +101,22 @@ def get_beam_pipeline_runner(
   # importing here to avoid beam pickling issues
   import firehook_resources  # pylint: disable=import-outside-toplevel
 
-  metadata_chooser_factory = IpMetadataChooserFactory(
-      firehook_resources.CAIDA_FILE_LOCATION,
-      firehook_resources.MAXMIND_FILE_LOCATION,
-      firehook_resources.DBIP_FILE_LOCATION)
-
   if env in ('dev', 'user'):
+    metadata_chooser_factory = IpMetadataChooserFactory(
+        firehook_resources.DEV_CAIDA_FILE_LOCATION,
+        firehook_resources.DEV_MAXMIND_FILE_LOCATION,
+        firehook_resources.DEV_DBIP_FILE_LOCATION)
+
     project_name = firehook_resources.DEV_PROJECT_NAME
     staging_location = firehook_resources.DEV_BEAM_STAGING_LOCATION
     temp_location = firehook_resources.DEV_BEAM_TEMP_LOCATION
     output_bucket = firehook_resources.DEV_OUTPUT_BUCKET
   if env == 'prod':
+    metadata_chooser_factory = IpMetadataChooserFactory(
+        firehook_resources.PROD_CAIDA_FILE_LOCATION,
+        firehook_resources.PROD_MAXMIND_FILE_LOCATION,
+        firehook_resources.PROD_DBIP_FILE_LOCATION)
+
     project_name = firehook_resources.PROD_PROJECT_NAME
     staging_location = firehook_resources.PROD_BEAM_STAGING_LOCATION
     temp_location = firehook_resources.PROD_BEAM_TEMP_LOCATION

--- a/prod.env
+++ b/prod.env
@@ -1,0 +1,1 @@
+PIPELINE_ENV=prod


### PR DESCRIPTION
Split out:
- reading/writing from dev/prod projects for the routeview/metadata files
- query read/writing to the dev vs prod projects
- running schedule.py in dev/prod
- deploying to dev/prod through docker (this required some trickiness to pass the env var through to docker)