### PR TITLE
pin api version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ apache-beam[gcp]==2.38.0
 geoip2==4.1.0
 # Imports GCS client needed for beam
 google-apitools==0.5.31
+# Setting core to avoid version conflict
+google-api-core==1.33.2
 google-api-python-client==1.12.8
 google-api-python-client-stubs==0.3.0
 google-cloud-bigquery==1.28.0


### PR DESCRIPTION
Seems like https://stackoverflow.com/questions/74673148/bigquery-client-using-python-timeout-and-polling-issues started on 2022-12-04, affecting us on 2022-12-08

Confirmed that the error
```
  File "/app/pipeline/beam_tables.py", line 90, in _get_existing_bq_datasources
    sources = [row.source for row in rows]
  File "/usr/local/lib/python3.8/site-packages/google/cloud/bigquery/job.py", line 3410, in __iter__
    return iter(self.result())
  File "/usr/local/lib/python3.8/site-packages/google/cloud/bigquery/job.py", line 3230, in result
    super(QueryJob, self).result(retry=retry, timeout=timeout)
  File "/usr/local/lib/python3.8/site-packages/google/cloud/bigquery/job.py", line 835, in result
    return super(_AsyncJob, self).result(timeout=timeout)
  File "/usr/local/lib/python3.8/site-packages/google/api_core/future/polling.py", line 256, in result
    self._blocking_poll(timeout=timeout, retry=retry, polling=polling)
TypeError: _blocking_poll() got an unexpected keyword argument 'retry'
```

happens on master, and not on this branch