### PR TITLE
add reshuffle to break data fusion

### DIFF
--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -585,6 +585,12 @@ class ScanDataBeamPipelineRunner():
       # PCollection[Tuple[filename,line]]
       lines = _read_scan_text(p, new_filenames)
 
+      # Reshuffle to break fusion on long files
+      # PCollection[Tuple[filename,line]]
+      lines = (
+          lines |
+          'reshuffle' >> beam.Reshuffle().with_output_types(Tuple[str, str]))
+
       if scan_type == schema.SCAN_TYPE_SATELLITE:
         # PCollection[SatelliteRow]
         rows = satellite.process_satellite_lines(lines, self.metadata_adder)


### PR DESCRIPTION
Add a reshuffle step after reading files to allow more parallelization. Otherwise some parsing work for lines is fused onto a single worker per file. This shortens the length of full backfills.

As suggested here:
![image](https://user-images.githubusercontent.com/1127209/227241853-063f2f95-a617-4e54-83af-a12d124e3049.png)
https://cloud.google.com/dataflow/docs/guides/using-dataflow-insights?&_ga=2.86777688.-1919799592.1676984832#high-fan-out

[Example job](https://console.cloud.google.com/dataflow/jobs/us-east4/2023-03-27_08_14_17-9463404791894821821?e=13802955&jsmode=o&mods=-ai_platform_fake_service,ai_platform_staging_service&project=firehook-censoredplanet) including the reshuffle step.

Here's an example comparison for http. 14 -> 4 hours
![image](https://user-images.githubusercontent.com/1127209/228194210-ddd113aa-3fb7-4163-96f3-f0d740c16ece.png)

TODO: still need to test that this doesn't cause OOM for satellite [here](https://console.cloud.google.com/dataflow/jobs/us-central1/2023-03-28_04_34_42-5878329324052163135?e=13802955&jsmode=o&mods=-ai_platform_fake_service,ai_platform_staging_service&project=firehook-censoredplanet). Edit: reduced job length from 14->5 hours
