### PR TITLE
add additional logging for metadata selection

### DIFF
--- a/pipeline/metadata/add_metadata.py
+++ b/pipeline/metadata/add_metadata.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import datetime
+import logging
 from typing import List, Tuple, Iterator, Iterable
 import uuid
 
@@ -200,6 +201,9 @@ class MetadataAdder():
     Yields:
       Tuples (DateIpKey, IpMetadataWithDateKey)
     """
+    logging.info(
+        f'Instantiating metadata tables for {date} to classify {len(ips)} IPs')
+
     ip_metadata_chooser = self.metadata_chooser_factory.make_chooser(
         datetime.date.fromisoformat(date))
 


### PR DESCRIPTION
Add some additional logging so we can see how many distinct ips we're classifying per day.

This will help figure out if our problems is somehow dropping ips for particular dates