### PR TITLE
ignore incorrect cert match values

### DIFF
--- a/pipeline/metadata/flatten_satellite.py
+++ b/pipeline/metadata/flatten_satellite.py
@@ -586,6 +586,4 @@ class FlattenBlockpages(beam.DoFn):
           self.blockpage_matcher, received, domain, 'satellite', True)
       https_row.received.tls_cert_has_trusted_ca = blockpage_entry.get(
           'trusted_cert', None)
-      https_row.received.tls_cert_matches_domain = blockpage_entry.get(
-          'cert_hostname_match', None)
     yield https_row

--- a/pipeline/metadata/test_flatten_satellite.py
+++ b/pipeline/metadata/test_flatten_satellite.py
@@ -1531,47 +1531,50 @@ class FlattenSatelliteTest(unittest.TestCase):
         "start_time": "2023-03-05 12:38:20.552810959 -0500 EST m=+45438.852453238",
         "end_time": "2023-03-05 12:38:22.239915361 -0500 EST m=+45440.539557726",
         "trusted_cert": True,
-        "cert_hostname_match": False
+        "cert_hostname_match": False  # Incorrect, this is a bug in the satellite scan code
     }
     # yapf: enable
 
     filename = 'gs://firehook-scans/satellite/CP-Satellite-2021-09-16-12-00-01/blockpages.json'
 
     expected_rows = [
-      PageFetchRow(received=HttpsResponse(status='301 Moved Permanently',),
-               domain='signal.org',
-               ip='54.192.18.30',
-               date='2023-03-05',
-               start_time='2023-03-05T12:38:20.552810959-05:00',
-               end_time='2023-03-05T12:38:22.239915361-05:00',
-               success=True,
-               https=False,
-               source='CP-Satellite-2021-09-16-12-00-01'
-               ),
-      PageFetchRow(received=HttpsResponse(status='200 OK',
-                                      tls_version=771,
-                                      tls_cipher_suite=49199,
-                                      tls_cert='MIIF8DCCBNigAwIBAgIQC1uSBIlDD6Rw9R+nheQWfTANBgkqhkiG9w0BAQsFADA8MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRwwGgYDVQQDExNBbWF6b24gUlNBIDIwNDggTTAxMB4XDTIzMDIyNDAwMDAwMFoXDTIzMDcwOTIzNTk1OVowGTEXMBUGA1UEAxMOd3d3LnNpZ25hbC5vcmcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDlBOgktuiIykveXmFSWWmpNLLPMqm2QnuIGZlSKVdCsJS9YLnfqQUZBWyKwt1/XD/KzmimC6K8B0RhqGpm+Ebm3hzGzoOiRS30Cx/BSeOMrBmjRh9Z3xlzPniMjl/1nkzvXME+Wl56DucfdbCJvnEt+OTVxbRyt/owJS2rLSUBR/ArOwFFr4J/F5MOetUI4N0LJPpgie+a7FNbD06OhQm2qqxSpCC8UPiViJxoNA8sdVomtN9fLmQOOy0NHV6Mo2sKV5SLHcDhzpm+SjXm+AxmxqYpgaKr5wkf+bR5objLt5hIUHuK1hbF76mhiF4oADLUSHyzUWmBl4ba9A1yRmBNAgMBAAGjggMPMIIDCzAfBgNVHSMEGDAWgBSBuA5jiokSGOX6OztQlZ/m5ZAThTAdBgNVHQ4EFgQUe8pndNmdDzyNqGdFuJRT3Fh4d24wQQYDVR0RBDowOIIOd3d3LnNpZ25hbC5vcmeCDnd3dy5zaWduYWwuYXJ0ggpzaWduYWwuYXJ0ggpzaWduYWwub3JnMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwOwYDVR0fBDQwMjAwoC6gLIYqaHR0cDovL2NybC5yMm0wMS5hbWF6b250cnVzdC5jb20vcjJtMDEuY3JsMBMGA1UdIAQMMAowCAYGZ4EMAQIBMHUGCCsGAQUFBwEBBGkwZzAtBggrBgEFBQcwAYYhaHR0cDovL29jc3AucjJtMDEuYW1hem9udHJ1c3QuY29tMDYGCCsGAQUFBzAChipodHRwOi8vY3J0LnIybTAxLmFtYXpvbnRydXN0LmNvbS9yMm0wMS5jZXIwDAYDVR0TAQH/BAIwADCCAX4GCisGAQQB1nkCBAIEggFuBIIBagFoAHYA6D7Q2j71BjUy51covIlryQPTy9ERa+zraeF3fW0GvW4AAAGGg8PN8QAABAMARzBFAiBcTrDvGCydKWiRe1sHXN4HWk/c2v4rAkiXJb8ku6roZgIhAOIZdCV0aqHYKWtN66RZ+g2J7pTx2MDmOa7FJKb07oaXAHcAs3N3B+GEUPhjhtYFqdwRCUp5LbFnDAuH3PADDnk2pZoAAAGGg8PN/gAABAMASDBGAiEAiQibozm7brZRAlU6hvSM/jHJ42752zeLnFTao1IGd7wCIQDDKyNEM9EEBTeahxo/znF4MU8/v+9UCrk8zFO5ljaJvAB1ALc++yTfnE26dfI5xbpY9Gxd/ELPep81xJ4dCYEl7bSZAAABhoPDzbEAAAQDAEYwRAIgTSKjciNjckdoZi6mMRwTbLs7LhxyiGnaFuX4lY/j2MECIB+qMEEtmQg3mpO1VGOySzs/+mC+rOH2GaDXV63vy3jGMA0GCSqGSIb3DQEBCwUAA4IBAQCyQSmJNq0Of2/rVOhD/IdrvdM0KRyxN8w7VErQzXMttMIhxPqYmDYSuKudV5/jaGd7cO/dycfpHcLl2kYaRtScwJDotsUWfBsNw0w9DXh4yvrPVjbnFucgZ5VZuX4jNYvJK9S/jZzBGSPkxAnCSVYTyhCYlUliNEJIBx0/pev7JdLe9FYsVqckOwK02lhbwvqa5U2QSYsPx1U+TIf92KxLb8cfKlxV79wGabHTF1TiWK6TIivDQCYC33om3hyoEkXitlLfXhjDn/a//TKQTYbAJ67SSG7Q8W6pp5mqIToq318a/jj3FCDg0HgMm1kzFDID+1olyE0QfLWtdxrJkCCX',
-                                      tls_cert_common_name='www.signal.org',
-                                      tls_cert_issuer='Amazon RSA 2048 M01',
-                                      tls_cert_start_date='2023-02-24T00:00:00',
-                                      tls_cert_end_date='2023-07-09T23:59:59',
-                                      tls_cert_alternative_names=['www.signal.org',
-                                                                  'www.signal.art',
-                                                                  'signal.art',
-                                                                  'signal.org'],
-                                      tls_cert_has_trusted_ca=True,
-                                      tls_cert_matches_domain=True,
-                                      headers=[]),
-               domain='signal.org',
-               ip='54.192.18.30',
-               date='2023-03-05',
-               start_time='2023-03-05T12:38:20.552810959-05:00',
-               end_time='2023-03-05T12:38:22.239915361-05:00',
-               success=True,
-               https=True,
-               source='CP-Satellite-2021-09-16-12-00-01'
-               )]
+        PageFetchRow(
+            received=HttpsResponse(status='301 Moved Permanently',),
+            domain='signal.org',
+            ip='54.192.18.30',
+            date='2023-03-05',
+            start_time='2023-03-05T12:38:20.552810959-05:00',
+            end_time='2023-03-05T12:38:22.239915361-05:00',
+            success=True,
+            https=False,
+            source='CP-Satellite-2021-09-16-12-00-01'),
+        PageFetchRow(
+            received=HttpsResponse(
+                status='200 OK',
+                tls_version=771,
+                tls_cipher_suite=49199,
+                tls_cert=
+                'MIIF8DCCBNigAwIBAgIQC1uSBIlDD6Rw9R+nheQWfTANBgkqhkiG9w0BAQsFADA8MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRwwGgYDVQQDExNBbWF6b24gUlNBIDIwNDggTTAxMB4XDTIzMDIyNDAwMDAwMFoXDTIzMDcwOTIzNTk1OVowGTEXMBUGA1UEAxMOd3d3LnNpZ25hbC5vcmcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDlBOgktuiIykveXmFSWWmpNLLPMqm2QnuIGZlSKVdCsJS9YLnfqQUZBWyKwt1/XD/KzmimC6K8B0RhqGpm+Ebm3hzGzoOiRS30Cx/BSeOMrBmjRh9Z3xlzPniMjl/1nkzvXME+Wl56DucfdbCJvnEt+OTVxbRyt/owJS2rLSUBR/ArOwFFr4J/F5MOetUI4N0LJPpgie+a7FNbD06OhQm2qqxSpCC8UPiViJxoNA8sdVomtN9fLmQOOy0NHV6Mo2sKV5SLHcDhzpm+SjXm+AxmxqYpgaKr5wkf+bR5objLt5hIUHuK1hbF76mhiF4oADLUSHyzUWmBl4ba9A1yRmBNAgMBAAGjggMPMIIDCzAfBgNVHSMEGDAWgBSBuA5jiokSGOX6OztQlZ/m5ZAThTAdBgNVHQ4EFgQUe8pndNmdDzyNqGdFuJRT3Fh4d24wQQYDVR0RBDowOIIOd3d3LnNpZ25hbC5vcmeCDnd3dy5zaWduYWwuYXJ0ggpzaWduYWwuYXJ0ggpzaWduYWwub3JnMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwOwYDVR0fBDQwMjAwoC6gLIYqaHR0cDovL2NybC5yMm0wMS5hbWF6b250cnVzdC5jb20vcjJtMDEuY3JsMBMGA1UdIAQMMAowCAYGZ4EMAQIBMHUGCCsGAQUFBwEBBGkwZzAtBggrBgEFBQcwAYYhaHR0cDovL29jc3AucjJtMDEuYW1hem9udHJ1c3QuY29tMDYGCCsGAQUFBzAChipodHRwOi8vY3J0LnIybTAxLmFtYXpvbnRydXN0LmNvbS9yMm0wMS5jZXIwDAYDVR0TAQH/BAIwADCCAX4GCisGAQQB1nkCBAIEggFuBIIBagFoAHYA6D7Q2j71BjUy51covIlryQPTy9ERa+zraeF3fW0GvW4AAAGGg8PN8QAABAMARzBFAiBcTrDvGCydKWiRe1sHXN4HWk/c2v4rAkiXJb8ku6roZgIhAOIZdCV0aqHYKWtN66RZ+g2J7pTx2MDmOa7FJKb07oaXAHcAs3N3B+GEUPhjhtYFqdwRCUp5LbFnDAuH3PADDnk2pZoAAAGGg8PN/gAABAMASDBGAiEAiQibozm7brZRAlU6hvSM/jHJ42752zeLnFTao1IGd7wCIQDDKyNEM9EEBTeahxo/znF4MU8/v+9UCrk8zFO5ljaJvAB1ALc++yTfnE26dfI5xbpY9Gxd/ELPep81xJ4dCYEl7bSZAAABhoPDzbEAAAQDAEYwRAIgTSKjciNjckdoZi6mMRwTbLs7LhxyiGnaFuX4lY/j2MECIB+qMEEtmQg3mpO1VGOySzs/+mC+rOH2GaDXV63vy3jGMA0GCSqGSIb3DQEBCwUAA4IBAQCyQSmJNq0Of2/rVOhD/IdrvdM0KRyxN8w7VErQzXMttMIhxPqYmDYSuKudV5/jaGd7cO/dycfpHcLl2kYaRtScwJDotsUWfBsNw0w9DXh4yvrPVjbnFucgZ5VZuX4jNYvJK9S/jZzBGSPkxAnCSVYTyhCYlUliNEJIBx0/pev7JdLe9FYsVqckOwK02lhbwvqa5U2QSYsPx1U+TIf92KxLb8cfKlxV79wGabHTF1TiWK6TIivDQCYC33om3hyoEkXitlLfXhjDn/a//TKQTYbAJ67SSG7Q8W6pp5mqIToq318a/jj3FCDg0HgMm1kzFDID+1olyE0QfLWtdxrJkCCX',
+                tls_cert_common_name='www.signal.org',
+                tls_cert_issuer='Amazon RSA 2048 M01',
+                tls_cert_start_date='2023-02-24T00:00:00',
+                tls_cert_end_date='2023-07-09T23:59:59',
+                tls_cert_alternative_names=[
+                    'www.signal.org', 'www.signal.art', 'signal.art',
+                    'signal.org'
+                ],
+                tls_cert_has_trusted_ca=True,
+                tls_cert_matches_domain=True,
+                headers=[]),
+            domain='signal.org',
+            ip='54.192.18.30',
+            date='2023-03-05',
+            start_time='2023-03-05T12:38:20.552810959-05:00',
+            end_time='2023-03-05T12:38:22.239915361-05:00',
+            success=True,
+            https=True,
+            source='CP-Satellite-2021-09-16-12-00-01')
+    ]
 
     flattener = get_blockpage_flattener()
     rows = flattener.process((filename, json.dumps(line)))


### PR DESCRIPTION
Some of the `cert_hostname_match` fields in the scan files are calculated with a bug. We were reading them in because we do need the `trusted_cert` field which is calculated at runtime with a live CA list. But we can ignore `cert_hostname_match` and only use the version calculated in the pipeline.

currently running a [dev backfill](https://console.cloud.google.com/dataflow/jobs/us-central1/2023-04-17_06_45_16-18151630545380331490?e=13802955&jsmode=o&mods=-ai_platform_fake_service,ai_platform_staging_service&project=firehook-censoredplanet) with this change

Here are the top [bad domains](https://lookerstudio.google.com/c/u/0/reporting/eca54448-dac2-49a1-a83b-188cfddaa306/page/p_5mukph02yc) before this fix:
![image](https://user-images.githubusercontent.com/1127209/232788586-31445198-4d98-4011-a98a-f578c237e75d.png)

and after:
![image](https://user-images.githubusercontent.com/1127209/232788639-1d62a3e4-0505-495f-928e-29350bbc6f2c.png)
