### PR TITLE
move cert matching before blockpages

### DIFF
--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -113,19 +113,19 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
                 WHEN (SELECT LOGICAL_OR(a.https_tls_cert_matches_domain AND a.https_tls_cert_has_trusted_ca)
                       FROM UNNEST(answers) a)
                       THEN "✅answer:valid_cert"
-                WHEN (SELECT LOGICAL_OR(answer.http_analysis_is_known_blockpage)
-                      FROM UNNEST(answers) answer)
-                      THEN CONCAT("❗️page:http_blockpage:", answers[OFFSET(0)].http_analysis_page_signature)
-                WHEN (SELECT LOGICAL_OR(answer.https_analysis_is_known_blockpage)
-                      FROM UNNEST(answers) answer)
-                      THEN CONCAT("❗️page:https_blockpage:", answers[OFFSET(0)].https_analysis_page_signature)
                 WHEN (SELECT LOGICAL_OR(a.https_tls_cert_matches_domain AND NOT a.https_tls_cert_has_trusted_ca)
                       FROM UNNEST(answers) a)
                       THEN CONCAT("❗️answer:invalid_ca_valid_domain:", answers[OFFSET(0)].https_tls_cert_issuer)
                 WHEN (SELECT LOGICAL_AND(NOT a.https_tls_cert_matches_domain)
                       FROM UNNEST(answers) a)
                       THEN CONCAT("❗️answer:cert_not_for_domain:", answers[OFFSET(0)].https_tls_cert_common_name)
-                -- We check AS after cert because we've seen (rare) cases of blockpages hosted on the ISP that also hosts Akamai servers.
+                WHEN (SELECT LOGICAL_OR(answer.http_analysis_is_known_blockpage)
+                      FROM UNNEST(answers) answer)
+                      THEN CONCAT("❗️page:http_blockpage:", answers[OFFSET(0)].http_analysis_page_signature)
+                WHEN (SELECT LOGICAL_OR(answer.https_analysis_is_known_blockpage)
+                      FROM UNNEST(answers) answer)
+                      THEN CONCAT("❗️page:https_blockpage:", answers[OFFSET(0)].https_analysis_page_signature)
+                -- We check AS after cert/blockpage because we've seen (rare) cases of blockpages hosted on the ISP that also hosts Akamai servers.
                 WHEN (SELECT LOGICAL_OR(answer.matches_control.asn)
                       FROM UNNEST(answers) answer)
                       THEN "✅answer:matches_asn"


### PR DESCRIPTION
Prioritize showing cert mismatches over blockpage matches, since they're a clear cryptographic sign something has gone wrong.

Here's an example diff from Indonesia:
![image](https://user-images.githubusercontent.com/1127209/236797112-060ab7da-c1c1-47dd-9db0-e1e9714929ef.png)

![image](https://user-images.githubusercontent.com/1127209/236797148-ee95584d-6838-4705-b958-f241d2743e23.png)

And from the overall data:
![image](https://user-images.githubusercontent.com/1127209/236797257-c6950b15-bbca-463e-9369-687d407093f3.png)

![image](https://user-images.githubusercontent.com/1127209/236797294-e29aa871-0806-4c32-a356-187fd6334f27.png)
