### PR TITLE
Split validation

### DIFF
--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -28,6 +28,66 @@ CREATE TEMP FUNCTION ClassifySatelliteRCode(rcode INTEGER) AS (
   END
 );
 
+# Classify all page fetch errors into a small set of enums
+#
+# Output is a string of the format "stage/outcome"
+# Documentation of this enum is at
+# https://github.com/censoredplanet/censoredplanet-analysis/blob/master/docs/tables.md#outcome-classification
+CREATE TEMP FUNCTION ClassifyPageFetchError(error STRING) AS (
+  CASE
+    # System failures
+    WHEN ENDS_WITH(error, "address already in use") THEN "setup/system_failure"
+    WHEN ENDS_WITH(error, "protocol error") THEN "setup/system_failure"
+    WHEN ENDS_WITH(error, "protocol not available") THEN "setup/system_failure" # ipv4 vs 6 error
+    WHEN ENDS_WITH(error, "too many open files") THEN "setup/system_failure"
+
+    # Dial failures
+    WHEN ENDS_WITH(error, "network is unreachable") THEN "dial/ip.network_unreachable"
+    WHEN ENDS_WITH(error, "no route to host") THEN "dial/ip.host_no_route"
+    WHEN ENDS_WITH(error, "connection refused") THEN "dial/tcp.refused"
+    WHEN ENDS_WITH(error, "context deadline exceeded") THEN "dial/timeout"
+    WHEN ENDS_WITH(error, "connect: connection timed out") THEN "dial/timeout"
+    WHEN STARTS_WITH(error, "connection reset by peer") THEN "dial/tcp.reset" #no read: or write: prefix in error
+    WHEN ENDS_WITH(error, "connect: connection reset by peer") THEN "dial/tcp.reset"
+    WHEN ENDS_WITH(error, "getsockopt: connection reset by peer") THEN "dial/tcp.reset"
+
+    # TLS failures
+    WHEN REGEXP_CONTAINS(error, "tls:") THEN "tls/tls.failed"
+    WHEN REGEXP_CONTAINS(error, "remote error:") THEN "tls/tls.failed"
+    WHEN REGEXP_CONTAINS(error, "local error:") THEN "tls/tls.failed"
+    WHEN ENDS_WITH(error, "readLoopPeekFailLocked: <nil>") THEN "tls/tls.failed"
+    WHEN ENDS_WITH(error, "missing ServerKeyExchange message") THEN "tls/tls.failed"
+    WHEN ENDS_WITH(error, "no mutual cipher suite") THEN "tls/tls.failed"
+    WHEN REGEXP_CONTAINS(error, "TLS handshake timeout") THEN "tls/timeout"
+
+    # Write failures
+    WHEN ENDS_WITH(error, "write: connection reset by peer") THEN "write/tcp.reset"
+    WHEN ENDS_WITH(error, "write: broken pipe") THEN "write/system"
+
+    # Read failures
+    WHEN REGEXP_CONTAINS(error, "request canceled") THEN "read/timeout"
+    WHEN ENDS_WITH(error, "i/o timeout") THEN "read/timeout"
+    WHEN ENDS_WITH(error, "shutdown: transport endpoint is not connected") THEN "read/system"
+    # TODO: for HTTPS this error could potentially also be SNI blocking in the tls stage
+    # find a way to diffentiate this case.
+    WHEN REGEXP_CONTAINS(error, "read: connection reset by peer") THEN "read/tcp.reset"
+
+    # HTTP content verification failures
+    WHEN REGEXP_CONTAINS(error, "unexpected EOF") THEN "read/http.truncated_response"
+    WHEN REGEXP_CONTAINS(error, "EOF") THEN "read/http.empty"
+    WHEN REGEXP_CONTAINS(error, "http: server closed idle connection") THEN "read/http.truncated_response"
+    WHEN ENDS_WITH(error, "trailer header without chunked transfer encoding") THEN "http/http.invalid"
+    WHEN ENDS_WITH(error, "response missing Location header") THEN "http/http.invalid"
+    WHEN REGEXP_CONTAINS(error, "bad Content-Length") THEN "http/http.invalid"
+    WHEN REGEXP_CONTAINS(error, "failed to parse Location header") THEN "http/http.invalid"
+    WHEN REGEXP_CONTAINS(error, "malformed HTTP") THEN "http/http.invalid"
+    WHEN REGEXP_CONTAINS(error, "malformed MIME") THEN "http/http.invalid"
+
+    # Unknown errors
+    ELSE "unknown/unknown"
+  END
+);
+
 CREATE TEMP FUNCTION ClassifySatelliteError(error STRING) AS (
   CASE
     # Satellite v1
@@ -127,7 +187,7 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
                       FROM UNNEST(answers) answer)
                       THEN "✅answer:matches_asn"
                 # We only reach this point if we weren't able to connect to the answer IP over HTTPS
-                ELSE CONCAT("❓answer:no_tcp_connection:", AnswersSignature(answers))
+                ELSE CONCAT("❓answer:no_tcp_connection:", ClassifyPageFetchError(answers[OFFSET(0)].https_error), ":", AnswersSignature(answers))
             END
         )
     END

--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -129,10 +129,11 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
                 WHEN (SELECT LOGICAL_OR(answer.matches_control.asn)
                       FROM UNNEST(answers) answer)
                       THEN "✅answer:matches_asn"
-                WHEN (SELECT LOGICAL_OR(NOT a.https_response_body IS NULL)
+                # TODO: delete, this case is covered by all the cert cases above
+                WHEN (SELECT LOGICAL_OR(NOT (a.https_response_status IS NULL))
                       FROM UNNEST(answers) a)
                       THEN CONCAT("❗️answer:unvalidated_https_connection:", AnswersSignature(answers))
-                WHEN (SELECT LOGICAL_OR(NOT a.http_response_body IS NULL)
+                WHEN (SELECT LOGICAL_OR(NOT (a.http_response_status IS NULL))
                       FROM UNNEST(answers) a)
                       THEN CONCAT("❗️answer:unvalidated_http_connection:", AnswersSignature(answers))
                 # We only reach this point if we weren't able to connect to the answer IP over either HTTPS or HTTP

--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -129,7 +129,10 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
                 WHEN (SELECT LOGICAL_OR(answer.matches_control.asn)
                       FROM UNNEST(answers) answer)
                       THEN "✅answer:matches_asn"
-                WHEN (SELECT LOGICAL_OR(a.http_response_body IS NOT NULL)
+                WHEN (SELECT LOGICAL_OR(NOT a.https_response_body IS NULL)
+                      FROM UNNEST(answers) a)
+                      THEN CONCAT("❗️answer:unvalidated_https_connection:", AnswersSignature(answers))
+                WHEN (SELECT LOGICAL_OR(NOT a.http_response_body IS NULL)
                       FROM UNNEST(answers) a)
                       THEN CONCAT("❗️answer:unvalidated_http_connection:", AnswersSignature(answers))
                 # We only reach this point if we weren't able to connect to the answer IP over either HTTPS or HTTP

--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -129,6 +129,12 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
                 WHEN (SELECT LOGICAL_OR(answer.matches_control.asn)
                       FROM UNNEST(answers) answer)
                       THEN "✅answer:matches_asn"
+                WHEN (SELECT LOGICAL_AND(a.http_response_body IS NULL AND a.https_response_body IS NULL)
+                      FROM UNNEST(answers) a)
+                      THEN CONCAT("❗️answer:no_http_connection:", AnswersSignature(answers))
+                WHEN (SELECT LOGICAL_AND(a.https_response_body IS NULL)
+                      FROM UNNEST(answers) a)
+                      THEN CONCAT("❗️answer:no_https_connection:", AnswersSignature(answers))
                 ELSE CONCAT("❓answer:not_validated:", AnswersSignature(answers))
             END
         )

--- a/table/queries/derived_satellite_scans.sql
+++ b/table/queries/derived_satellite_scans.sql
@@ -129,13 +129,11 @@ CREATE TEMP FUNCTION OutcomeString(domain_name STRING,
                 WHEN (SELECT LOGICAL_OR(answer.matches_control.asn)
                       FROM UNNEST(answers) answer)
                       THEN "✅answer:matches_asn"
-                WHEN (SELECT LOGICAL_AND(a.http_response_body IS NULL AND a.https_response_body IS NULL)
+                WHEN (SELECT LOGICAL_OR(a.http_response_body IS NOT NULL)
                       FROM UNNEST(answers) a)
-                      THEN CONCAT("❗️answer:no_http_connection:", AnswersSignature(answers))
-                WHEN (SELECT LOGICAL_AND(a.https_response_body IS NULL)
-                      FROM UNNEST(answers) a)
-                      THEN CONCAT("❗️answer:no_https_connection:", AnswersSignature(answers))
-                ELSE CONCAT("❓answer:not_validated:", AnswersSignature(answers))
+                      THEN CONCAT("❗️answer:unvalidated_http_connection:", AnswersSignature(answers))
+                # We only reach this point if we weren't able to connect to the answer IP over either HTTPS or HTTP
+                ELSE CONCAT("❓answer:no_tcp_connection:", AnswersSignature(answers))
             END
         )
     END


### PR DESCRIPTION
This splits `answer:not_validated` into `answer:unvalidated_http_connection` and `answer:no_tcp_connection` (when we were not able to connect to the answer ip at all.

I'd like suggestions about:
- the clearest (short) names to use for these outcome
- thoughts on this approach overall. I think trying to break out `not_validated` further is useful, since it's 60% of our unexpected outcomes. But I don't have a full theory of how this new information is actionable.
- Do we want to break out `answer:no_tcp_connection` further, by splitting along different types of connection errors? (timeout, no route, etc)

dashboard with this data: [here](https://lookerstudio.google.com/c/u/0/reporting/d6e93931-f621-46cb-8f37-1a8186db7be4/page/p_frq2r0hs5c?params=%7B%22df33%22:%22include%25EE%2580%25800%25EE%2580%2580IN%25EE%2580%2580%25E2%259D%2597%25EF%25B8%258Fpage%253Ahttp_blockpage%22%7D)

Here's the new outcome breakdown
![image](https://github.com/censoredplanet/censoredplanet-analysis/assets/1127209/c6ce3c5f-4d45-4580-9ac8-0d60ee362650)

