### PR TITLE
limit derived queries to one year

### DIFF
--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Only process a year's worth of the hyperquack data for costs savings purposes
+# TODO remove this once we are able to run appending queries instead.
+# Not needed for satellite since we already output restricted data from the pipeline
 DECLARE earliest_date DATE;
 SET earliest_date = DATE_SUB(CURRENT_DATE, INTERVAL 1 YEAR);
 


### PR DESCRIPTION
to reduce backend costs.

The costs of the hyperquack query goes from $34 -> 7

Currently this change breaks the e2e test (since it depends on reading the output of running the query, and has older data) But that's hard to fix since the e2e test runs in a particularly contrived way. I think it's okay in the short term.

Here are our pre-existing costs for a single day in dev when no one was using the dashboard (more analysis [here](https://docs.google.com/document/d/1ZVAlCS1RX6Kuq0p5S1wcwQ3s6qx0eN28_xYBUmjujA0/edit#heading=h.8r2orc94s0se))
![image](https://github.com/censoredplanet/censoredplanet-analysis/assets/1127209/7acca0c6-332c-4515-a1da-ff0e203ebe7b)


