### PR TITLE
run weekly instead of daily

### DIFF
--- a/schedule_pipeline.py
+++ b/schedule_pipeline.py
@@ -72,7 +72,7 @@ def run(env: str) -> None:
   """
   run_pipeline(env)  # run once when starting to catch new errors when deploying
 
-  schedule.every().day.at('04:00').do(run_pipeline, env)
+  schedule.every().monday.at('04:00').do(run_pipeline, env)
 
   while True:
     schedule.run_pending()


### PR DESCRIPTION
Another temporary measure for turning nightly on (merging to `prod-side`). This will run the pipeline weekly instead of daily.