### PR TITLE
upgrade python version to 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
 
         python -m pip install --upgrade pip
-        pip install mypy yapf pylint -r requirements.txt
+        pip install mypy==1.0.0 yapf pylint -r requirements.txt
     - name: Check types with mypy
       # Get all files with find because ** doesn't expand correctly.
       # Run mypy twice, once to find missing stub packeges, then again after installing them.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# 3.8 (not 3.9) is required for apache beam
-FROM python:3.8-buster
+FROM python:3.9-buster
 
 # Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True


### PR DESCRIPTION
apache-beam works with python3.9 by [now](https://beam.apache.org/blog/beam-2.37.0/)

Freezing the mypy version is to fix [this issue](https://github.com/censoredplanet/censoredplanet-analysis/actions/runs/5999714316/job/16270390242?pr=252) with the github CI checking. The latest version of mypy imports typing_extensions.Self, which is only available in python 3.11. 1.0.0 was released 2023-02-06 and seems like a nice place to freeze.